### PR TITLE
Add auto-config for the tracer resolver

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -22,3 +22,13 @@ target
 
 # virtual machine crash logs, see http://www.java.com/en/download/help/error_hotspot.xml
 hs_err_pid*
+
+# IntelliJ project files
+.idea/
+*.iml
+
+# Eclipse
+.project
+.classpath
+.settings
+

--- a/opentracing-spring-cloud-tracerresolver/pom.xml
+++ b/opentracing-spring-cloud-tracerresolver/pom.xml
@@ -1,0 +1,46 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+  xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+  xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>io.opentracing.contrib</groupId>
+    <artifactId>opentracing-spring-cloud-parent</artifactId>
+    <version>0.0.1-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>opentracing-spring-cloud-tracerresolver</artifactId>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.opentracing.contrib</groupId>
+      <artifactId>opentracing-tracerresolver</artifactId>
+      <version>${version.io.opentracing.contrib-opentracing-tracerresolver}</version>
+      <scope>provided</scope>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-autoconfigure</artifactId>
+      <version>${version.org.springframework.boot}</version>
+    </dependency>
+
+    <dependency>
+      <groupId>io.opentracing</groupId>
+      <artifactId>opentracing-mock</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <version>${version.org.springframework.boot}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+      <version>${version.org.springframework.boot}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/opentracing-spring-cloud-tracerresolver/src/main/java/io/opentracing/contrib/spring/cloud/tracerresolver/TracerResolverConfiguration.java
+++ b/opentracing-spring-cloud-tracerresolver/src/main/java/io/opentracing/contrib/spring/cloud/tracerresolver/TracerResolverConfiguration.java
@@ -1,0 +1,31 @@
+/**
+ * Copyright 2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.contrib.spring.cloud.tracerresolver;
+
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+import io.opentracing.contrib.tracerresolver.TracerResolver;
+
+@Configuration
+@ConditionalOnClass(value = {TracerResolver.class})
+public class TracerResolverConfiguration {
+
+    @Bean
+    public io.opentracing.Tracer tracer() {
+        return TracerResolver.resolveTracer();
+    }
+
+}

--- a/opentracing-spring-cloud-tracerresolver/src/main/resources/META-INF/spring.factories
+++ b/opentracing-spring-cloud-tracerresolver/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+io.opentracing.contrib.spring.cloud.tracerresolver.TracerResolverConfiguration

--- a/opentracing-spring-cloud-tracerresolver/src/test/java/io/opentracing/contrib/spring/cloud/tracerresolver/MockTracerResolver.java
+++ b/opentracing-spring-cloud-tracerresolver/src/test/java/io/opentracing/contrib/spring/cloud/tracerresolver/MockTracerResolver.java
@@ -1,0 +1,27 @@
+/**
+ * Copyright 2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.contrib.spring.cloud.tracerresolver;
+
+import io.opentracing.Tracer;
+import io.opentracing.contrib.tracerresolver.TracerResolver;
+import io.opentracing.mock.MockTracer;
+
+public class MockTracerResolver extends TracerResolver {
+
+    @Override
+    protected Tracer resolve() {
+        return new MockTracer();
+    }
+
+}

--- a/opentracing-spring-cloud-tracerresolver/src/test/java/io/opentracing/contrib/spring/cloud/tracerresolver/TracerResolverConfigurationTest.java
+++ b/opentracing-spring-cloud-tracerresolver/src/test/java/io/opentracing/contrib/spring/cloud/tracerresolver/TracerResolverConfigurationTest.java
@@ -1,0 +1,46 @@
+/**
+ * Copyright 2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.contrib.spring.cloud.tracerresolver;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import io.opentracing.Tracer;
+import io.opentracing.mock.MockTracer;
+
+@SpringBootTest
+@RunWith(SpringJUnit4ClassRunner.class)
+public class TracerResolverConfigurationTest {
+
+    @Autowired(required=false)
+    protected Tracer tracer;
+
+    @Configuration
+    @EnableAutoConfiguration
+    public static class SpringConfiguration {
+    }
+
+    @Test
+    public void testTracerResolved() {
+        assertEquals(MockTracer.class, tracer.getClass());
+    }
+
+}

--- a/opentracing-spring-cloud-tracerresolver/src/test/java/io/opentracing/contrib/spring/cloud/tracerresolver/TracerResolverConfigurationTest.java
+++ b/opentracing-spring-cloud-tracerresolver/src/test/java/io/opentracing/contrib/spring/cloud/tracerresolver/TracerResolverConfigurationTest.java
@@ -30,7 +30,7 @@ import io.opentracing.mock.MockTracer;
 @RunWith(SpringJUnit4ClassRunner.class)
 public class TracerResolverConfigurationTest {
 
-    @Autowired(required=false)
+    @Autowired
     protected Tracer tracer;
 
     @Configuration

--- a/opentracing-spring-cloud-tracerresolver/src/test/resources/META-INF/services/io.opentracing.contrib.tracerresolver.TracerResolver
+++ b/opentracing-spring-cloud-tracerresolver/src/test/resources/META-INF/services/io.opentracing.contrib.tracerresolver.TracerResolver
@@ -1,0 +1,1 @@
+io.opentracing.contrib.spring.cloud.tracerresolver.MockTracerResolver

--- a/pom.xml
+++ b/pom.xml
@@ -7,6 +7,7 @@
   <version>0.0.1-SNAPSHOT</version>
   <modules>
     <module>opentracing-spring-cloud</module>
+    <module>opentracing-spring-cloud-tracerresolver</module>
   </modules>
   <packaging>pom</packaging>
 
@@ -44,6 +45,7 @@
 
     <version.io.opentracing>0.30.0</version.io.opentracing>
     <version.io.opentracing.contrib-opentracing-spring-web>0.0.6</version.io.opentracing.contrib-opentracing-spring-web>
+    <version.io.opentracing.contrib-opentracing-tracerresolver>0.1.0</version.io.opentracing.contrib-opentracing-tracerresolver>
     <version.org.springframework.boot>1.4.3.RELEASE</version.org.springframework.boot>
     <version.org.awaitility-awaitility>3.0.0</version.org.awaitility-awaitility>
 


### PR DESCRIPTION
This PR extracts the tracer resolver auto-config from https://github.com/opentracing-contrib/java-spring-cloud/pull/15.