### PR TITLE
Initial Spring Messaging tracing code

### DIFF
--- a/opentracing-spring-messaging/pom.xml
+++ b/opentracing-spring-messaging/pom.xml
@@ -1,0 +1,94 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2017 The OpenTracing Authors
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+    in compliance with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the License
+    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+    or implied. See the License for the specific language governing permissions and limitations under
+    the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>io.opentracing.contrib</groupId>
+    <artifactId>opentracing-spring-cloud-parent</artifactId>
+    <version>0.0.7-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>opentracing-spring-messaging</artifactId>
+
+  <properties>
+    <main.basedir>${project.basedir}/..</main.basedir>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.opentracing</groupId>
+      <artifactId>opentracing-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.integration</groupId>
+      <artifactId>spring-integration-core</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-messaging</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>junit</groupId>
+      <artifactId>junit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.mockito</groupId>
+      <artifactId>mockito-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.opentracing</groupId>
+      <artifactId>opentracing-mock</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.opentracing</groupId>
+      <artifactId>opentracing-util</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+  <build>
+    <plugins>
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-failsafe-plugin</artifactId>
+        <executions>
+          <execution>
+            <goals>
+              <goal>integration-test</goal>
+              <goal>verify</goal>
+            </goals>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/opentracing-spring-messaging/src/main/java/io/opentracing/contrib/spring/integration/messaging/Events.java
+++ b/opentracing-spring-messaging/src/main/java/io/opentracing/contrib/spring/integration/messaging/Events.java
@@ -1,0 +1,32 @@
+/**
+ * Copyright 2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.opentracing.contrib.spring.integration.messaging;
+
+/**
+ * @author <a href="mailto:gytis@redhat.com">Gytis Trikleris</a>
+ */
+public final class Events {
+
+  public static final String CLIENT_SEND = "cs";
+
+  public static final String CLIENT_RECEIVE = "cr";
+
+  public static final String SERVER_SEND = "ss";
+
+  public static final String SERVER_RECEIVE = "sr";
+
+  public static final String ERROR = "error";
+
+}

--- a/opentracing-spring-messaging/src/main/java/io/opentracing/contrib/spring/integration/messaging/Events.java
+++ b/opentracing-spring-messaging/src/main/java/io/opentracing/contrib/spring/integration/messaging/Events.java
@@ -16,6 +16,7 @@ package io.opentracing.contrib.spring.integration.messaging;
 
 /**
  * @author <a href="mailto:gytis@redhat.com">Gytis Trikleris</a>
+ *     -TODO REMOVE
  */
 public final class Events {
 
@@ -26,7 +27,4 @@ public final class Events {
   public static final String SERVER_SEND = "ss";
 
   public static final String SERVER_RECEIVE = "sr";
-
-  public static final String ERROR = "error";
-
 }

--- a/opentracing-spring-messaging/src/main/java/io/opentracing/contrib/spring/integration/messaging/Headers.java
+++ b/opentracing-spring-messaging/src/main/java/io/opentracing/contrib/spring/integration/messaging/Headers.java
@@ -1,0 +1,24 @@
+/**
+ * Copyright 2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.opentracing.contrib.spring.integration.messaging;
+
+/**
+ * @author <a href="mailto:gytis@redhat.com">Gytis Trikleris</a>
+ */
+public final class Headers {
+
+  public static final String MESSAGE_SENT_FROM_CLIENT = "messageSent";
+
+}

--- a/opentracing-spring-messaging/src/main/java/io/opentracing/contrib/spring/integration/messaging/Headers.java
+++ b/opentracing-spring-messaging/src/main/java/io/opentracing/contrib/spring/integration/messaging/Headers.java
@@ -18,7 +18,6 @@ package io.opentracing.contrib.spring.integration.messaging;
  * @author <a href="mailto:gytis@redhat.com">Gytis Trikleris</a>
  */
 public final class Headers {
-
   public static final String MESSAGE_SENT_FROM_CLIENT = "messageSent";
-
+  public static final String MESSAGE_CONSUMED = "messageConsumed";
 }

--- a/opentracing-spring-messaging/src/main/java/io/opentracing/contrib/spring/integration/messaging/MessageTextMap.java
+++ b/opentracing-spring-messaging/src/main/java/io/opentracing/contrib/spring/integration/messaging/MessageTextMap.java
@@ -1,0 +1,65 @@
+/**
+ * Copyright 2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.opentracing.contrib.spring.integration.messaging;
+
+import io.opentracing.propagation.TextMap;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.support.GenericMessage;
+import org.springframework.messaging.support.MessageHeaderAccessor;
+
+/**
+ * @author <a href="mailto:gytis@redhat.com">Gytis Trikleris</a>
+ */
+public class MessageTextMap<T> implements TextMap {
+
+  private final Message<T> message;
+
+  private final Map<String, String> headers;
+
+  public MessageTextMap(Message<T> message) {
+    this.message = message;
+    this.headers = extractStringHeaders(message);
+  }
+
+  @Override
+  public Iterator<Map.Entry<String, String>> iterator() {
+    return headers.entrySet()
+        .iterator();
+  }
+
+  @Override
+  public void put(String key, String value) {
+    headers.put(key, value);
+  }
+
+  public Message<T> getMessage() {
+    MessageHeaderAccessor headerAccessor = MessageHeaderAccessor.getMutableAccessor(message);
+    headerAccessor.copyHeaders(headers);
+
+    return new GenericMessage<>(message.getPayload(), headerAccessor.getMessageHeaders());
+  }
+
+  private Map<String, String> extractStringHeaders(Message<?> message) {
+    Map<String, Object> objectHeaders = message.getHeaders();
+    Map<String, String> stringHeaders = new HashMap<>(objectHeaders.size());
+
+    objectHeaders.forEach((k, v) -> stringHeaders.put(k, String.valueOf(v)));
+
+    return stringHeaders;
+  }
+}

--- a/opentracing-spring-messaging/src/main/java/io/opentracing/contrib/spring/integration/messaging/OpenTracingChannelInterceptor.java
+++ b/opentracing-spring-messaging/src/main/java/io/opentracing/contrib/spring/integration/messaging/OpenTracingChannelInterceptor.java
@@ -1,0 +1,168 @@
+/**
+ * Copyright 2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.opentracing.contrib.spring.integration.messaging;
+
+import io.opentracing.ActiveSpan;
+import io.opentracing.SpanContext;
+import io.opentracing.Tracer;
+import io.opentracing.propagation.Format;
+import io.opentracing.tag.Tags;
+import java.util.Collections;
+import org.apache.commons.logging.Log;
+import org.apache.commons.logging.LogFactory;
+import org.springframework.integration.channel.AbstractMessageChannel;
+import org.springframework.integration.context.IntegrationObjectSupport;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.MessageHandler;
+import org.springframework.messaging.support.ChannelInterceptorAdapter;
+import org.springframework.messaging.support.ExecutorChannelInterceptor;
+import org.springframework.util.ClassUtils;
+
+/**
+ * @author <a href="mailto:gytis@redhat.com">Gytis Trikleris</a>
+ */
+public class OpenTracingChannelInterceptor extends ChannelInterceptorAdapter implements ExecutorChannelInterceptor {
+
+  private static final Log log = LogFactory.getLog(OpenTracingChannelInterceptor.class);
+
+  private static final String COMPONENT_TAG = "spring-messaging";
+
+  private static final String MESSAGE_COMPONENT = "message";
+
+  private final Tracer tracer;
+
+  public OpenTracingChannelInterceptor(Tracer tracer) {
+    this.tracer = tracer;
+  }
+
+  @Override
+  public Message<?> preSend(Message<?> message, MessageChannel channel) {
+    log.trace("Processing message before sending it to the channel");
+
+    MessageTextMap<?> carrier = new MessageTextMap<>(message);
+    SpanContext parentSpan = tracer.extract(Format.Builtin.TEXT_MAP, carrier);
+    String operationName = getOperationName(channel);
+    ActiveSpan span = tracer.buildSpan(operationName)
+        .asChildOf(parentSpan)
+        .startActive();
+
+    Tags.COMPONENT.set(span, COMPONENT_TAG);
+    Tags.MESSAGE_BUS_DESTINATION.set(span, getChannelName(channel));
+
+    if (message.getHeaders()
+        .containsKey(Headers.MESSAGE_SENT_FROM_CLIENT)) {
+      log.trace("Marking span with server received");
+      span.log(Events.SERVER_RECEIVE);
+      span.setBaggageItem(Events.SERVER_RECEIVE, Events.SERVER_RECEIVE);
+      Tags.SPAN_KIND.set(span, Tags.SPAN_KIND_CONSUMER);
+      // TODO maybe we should remove Headers.MESSAGE_SENT_FROM_CLIENT header here?
+    } else {
+      log.trace("Marking span with client send");
+      span.log(Events.CLIENT_SEND);
+      Tags.SPAN_KIND.set(span, Tags.SPAN_KIND_PRODUCER);
+      carrier.put(Headers.MESSAGE_SENT_FROM_CLIENT, "true");
+    }
+
+    tracer.inject(span.context(), Format.Builtin.TEXT_MAP, carrier);
+
+    return carrier.getMessage();
+  }
+
+  @Override
+  public void afterSendCompletion(Message<?> message, MessageChannel channel, boolean sent, Exception ex) {
+    ActiveSpan activeSpan = tracer.activeSpan();
+
+    log.trace(String.format("Completed sending and current span is %s", activeSpan));
+
+    if (activeSpan == null) {
+      return;
+    }
+
+    if (activeSpan.getBaggageItem(Events.SERVER_RECEIVE) != null) {
+      log.trace("Marking span with server send");
+      activeSpan.log(Events.SERVER_SEND);
+    } else {
+      log.debug("Marking span with client received");
+      activeSpan.log(Events.CLIENT_RECEIVE);
+    }
+
+    if (ex != null) {
+      activeSpan.log(Collections.singletonMap(Events.ERROR, ex.getMessage()));
+    }
+
+    log.trace("Closing messaging span " + activeSpan);
+    activeSpan.close();
+    log.trace(String.format("Messaging span %s successfully closed", activeSpan));
+  }
+
+  @Override
+  public Message<?> beforeHandle(Message<?> message, MessageChannel channel, MessageHandler handler) {
+    ActiveSpan activeSpan = tracer.activeSpan();
+
+    log.trace(String.format("Continuing span %s before handling message", activeSpan));
+
+    if (activeSpan != null) {
+      log.trace("Marking span with server received");
+      activeSpan.log(Events.SERVER_RECEIVE);
+      log.trace(String.format("Span %s successfully continued", activeSpan));
+    }
+
+    return message;
+  }
+
+  @Override
+  public void afterMessageHandled(Message<?> message, MessageChannel channel, MessageHandler handler, Exception ex) {
+    ActiveSpan activeSpan = tracer.activeSpan();
+
+    log.trace(String.format("Continuing span %s after message handled", activeSpan));
+
+    if (activeSpan == null) {
+      return;
+    }
+
+    log.trace("Marking span with server send");
+    activeSpan.log(Events.SERVER_SEND);
+
+    if (ex != null) {
+      activeSpan.log(Collections.singletonMap(Events.ERROR, ex.getMessage()));
+    }
+  }
+
+  private String getChannelName(MessageChannel messageChannel) {
+    String name = null;
+    if (ClassUtils.isPresent("org.springframework.integration.context.IntegrationObjectSupport", null)) {
+      if (messageChannel instanceof IntegrationObjectSupport) {
+        name = ((IntegrationObjectSupport) messageChannel).getComponentName();
+      }
+      if (name == null && messageChannel instanceof AbstractMessageChannel) {
+        name = ((AbstractMessageChannel) messageChannel).getFullChannelName();
+      }
+    }
+
+    if (name == null) {
+      return messageChannel.toString();
+    }
+
+    return name;
+  }
+
+  private String getOperationName(MessageChannel messageChannel) {
+    String channelName = getChannelName(messageChannel);
+
+    return String.format("%s:%s", MESSAGE_COMPONENT, channelName);
+  }
+
+}

--- a/opentracing-spring-messaging/src/test/java/io/opentracing/contrib/spring/integration/messaging/MessageTextMapTest.java
+++ b/opentracing-spring-messaging/src/test/java/io/opentracing/contrib/spring/integration/messaging/MessageTextMapTest.java
@@ -1,0 +1,66 @@
+/**
+ * Copyright 2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.opentracing.contrib.spring.integration.messaging;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import java.util.AbstractMap;
+import java.util.HashMap;
+import java.util.Map;
+import org.junit.Test;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.support.MessageBuilder;
+
+/**
+ * @author <a href="mailto:gytis@redhat.com">Gytis Trikleris</a>
+ */
+public class MessageTextMapTest {
+
+  @Test
+  public void shouldGetIterator() {
+    Map<String, String> headers = new HashMap<>(2);
+    headers.put("h1", "v1");
+    headers.put("h2", "v2");
+    Message<String> message = MessageBuilder.withPayload("test")
+        .copyHeaders(headers)
+        .build();
+    MessageTextMap<String> map = new MessageTextMap<>(message);
+
+    assertThat(map.iterator()).containsAll(headers.entrySet());
+  }
+
+  @Test
+  public void shouldPutEntry() {
+    Message<String> message = MessageBuilder.withPayload("test")
+        .build();
+    MessageTextMap<String> map = new MessageTextMap<>(message);
+    map.put("k1", "v1");
+
+    assertThat(map.iterator()).contains(new AbstractMap.SimpleEntry<>("k1", "v1"));
+  }
+
+  @Test
+  public void shouldGetMessageWithNewHeaders() {
+    Message<String> message = MessageBuilder.withPayload("test")
+        .build();
+    MessageTextMap<String> map = new MessageTextMap<>(message);
+    map.put("k1", "v1");
+    Message<String> updatedMessage = map.getMessage();
+
+    assertThat(updatedMessage.getPayload()).isEqualTo(message.getPayload());
+    assertThat(updatedMessage.getHeaders()).contains(new AbstractMap.SimpleEntry<>("k1", "v1"));
+  }
+
+}

--- a/opentracing-spring-messaging/src/test/java/io/opentracing/contrib/spring/integration/messaging/OpenTracingChannelInterceptorIT.java
+++ b/opentracing-spring-messaging/src/test/java/io/opentracing/contrib/spring/integration/messaging/OpenTracingChannelInterceptorIT.java
@@ -1,0 +1,348 @@
+/**
+ * Copyright 2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.opentracing.contrib.spring.integration.messaging;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.fail;
+import static org.assertj.core.api.BDDAssertions.then;
+
+import io.opentracing.Tracer;
+import io.opentracing.mock.MockSpan;
+import io.opentracing.mock.MockTracer;
+import io.opentracing.util.ThreadLocalActiveSpanSource;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Ignore;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.integration.channel.DirectChannel;
+import org.springframework.integration.channel.QueueChannel;
+import org.springframework.integration.config.GlobalChannelInterceptor;
+import org.springframework.integration.core.MessagingTemplate;
+import org.springframework.integration.support.MessageBuilder;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageHandler;
+import org.springframework.messaging.MessagingException;
+import org.springframework.messaging.PollableChannel;
+import org.springframework.messaging.support.MessageHeaderAccessor;
+import org.springframework.test.annotation.DirtiesContext;
+import org.springframework.test.context.junit4.SpringRunner;
+
+/**
+ * Note: these tests were adapted for Open Tracing from Spring Cloud Sleuth project.
+ *
+ * @author <a href="mailto:gytis@redhat.com">Gytis Trikleris</a>
+ */
+@RunWith(SpringRunner.class)
+@SpringBootTest(classes = OpenTracingChannelInterceptorIT.App.class,
+    webEnvironment = SpringBootTest.WebEnvironment.NONE)
+@DirtiesContext
+public class OpenTracingChannelInterceptorIT implements MessageHandler {
+
+  private static final String TRACE_ID_HEADER = "traceid";
+
+  private static final String SPAN_ID_HEADER = "spanid";
+
+  private static final String THROW_EXCEPTION_HEADER = "THROW_EXCEPTION";
+
+  @Autowired
+  @Qualifier("tracedChannel")
+  private DirectChannel tracedChannel;
+
+  @Autowired
+  @Qualifier("pollableChannel")
+  private PollableChannel pollableChannel;
+
+  @Autowired
+  private MockTracer mockTracer;
+
+  @Autowired
+  private MessagingTemplate messagingTemplate;
+
+  private Message<?> message;
+
+  @Override
+  public void handleMessage(Message<?> message) throws MessagingException {
+    this.message = message;
+    if (message.getHeaders()
+        .containsKey(THROW_EXCEPTION_HEADER)) {
+      throw new RuntimeException("A terrible exception has occurred");
+    }
+  }
+
+  @Before
+  public void before() {
+    tracedChannel.subscribe(this);
+    mockTracer.reset();
+  }
+
+  @After
+  public void after() {
+    tracedChannel.unsubscribe(this);
+    mockTracer.reset();
+  }
+
+  @Test
+  public void shouldCreateSpan() {
+    tracedChannel.send(MessageBuilder.withPayload("hi")
+        .build());
+    assertThat(message).isNotNull();
+    then(message.getPayload()).isEqualTo("hi");
+    then(message.getHeaders()).containsKeys(TRACE_ID_HEADER, SPAN_ID_HEADER);
+    then(mockTracer.finishedSpans()).hasSize(1);
+  }
+
+  @Test
+  public void shouldKeepHeadersMutable() {
+    tracedChannel.send(MessageBuilder.withPayload("hi")
+        .build());
+    assertThat(message).isNotNull();
+
+    MessageHeaderAccessor accessor = MessageHeaderAccessor.getAccessor(message, MessageHeaderAccessor.class);
+    assertThat(accessor).isNotNull();
+  }
+
+  @Test
+  public void shouldPropagateTraceViaPollableChannel() {
+    pollableChannel.send(MessageBuilder.withPayload("hi")
+        .build());
+    Message<?> message = pollableChannel.receive(0);
+    assertThat(message).isNotNull();
+    then(message.getPayload()).isEqualTo("hi");
+    then(message.getHeaders()).containsKeys(TRACE_ID_HEADER, SPAN_ID_HEADER);
+    then(mockTracer.finishedSpans()).hasSize(1);
+  }
+
+  @Test
+  public void shouldCreateSpanWithExportedParent() {
+    tracedChannel.send(MessageBuilder.withPayload("hi")
+        .setHeader(TRACE_ID_HEADER, "100")
+        .setHeader(SPAN_ID_HEADER, "200")
+        .build());
+    then(message).isNotNull();
+    then(message.getHeaders()).containsKeys(TRACE_ID_HEADER, SPAN_ID_HEADER);
+    then(mockTracer.finishedSpans()).hasSize(1);
+
+    Long traceId = Long.valueOf(message.getHeaders()
+        .get(TRACE_ID_HEADER, String.class));
+    Long spanId = Long.valueOf(message.getHeaders()
+        .get(SPAN_ID_HEADER, String.class));
+
+    then(traceId).isEqualTo(100);
+    then(spanId).isNotEqualTo(200);
+
+    MockSpan finishedSpan = mockTracer.finishedSpans()
+        .get(0);
+    then(finishedSpan.parentId()).isEqualTo(200);
+
+    MockSpan.MockContext finishedSpanContext = finishedSpan.context();
+    then(finishedSpanContext.traceId()).isEqualTo(traceId);
+    then(finishedSpanContext.spanId()).isEqualTo(spanId);
+  }
+
+  @Test
+  public void shouldCreateSpanWithActiveParent() {
+    MockSpan parentSpan = mockTracer.buildSpan("http:testSendMessage")
+        .start();
+    mockTracer.makeActive(parentSpan);
+
+    tracedChannel.send(MessageBuilder.withPayload("hi")
+        .build());
+    then(message).isNotNull();
+    then(message.getHeaders()).containsKeys(TRACE_ID_HEADER, SPAN_ID_HEADER);
+    then(mockTracer.finishedSpans()).hasSize(1); // TODO because parent span is not finished
+
+    Long traceId = Long.valueOf(message.getHeaders()
+        .get(TRACE_ID_HEADER, String.class));
+    Long spanId = Long.valueOf(message.getHeaders()
+        .get(SPAN_ID_HEADER, String.class));
+
+    MockSpan.MockContext parentSpanContext = parentSpan.context();
+
+    then(traceId).isEqualTo(parentSpanContext.traceId());
+    then(spanId).isNotEqualTo(parentSpanContext.spanId());
+
+    MockSpan finishedSpan = mockTracer.finishedSpans()
+        .get(0);
+    then(finishedSpan.parentId()).isEqualTo(parentSpanContext.spanId());
+
+    MockSpan.MockContext finishedSpanContext = finishedSpan.context();
+    then(finishedSpanContext.traceId()).isEqualTo(traceId);
+    then(finishedSpanContext.spanId()).isEqualTo(spanId);
+  }
+
+  @Test
+  public void shouldCreateHeadersWhenUsingMessagingTemplate() {
+    messagingTemplate.send(MessageBuilder.withPayload("hi")
+        .build());
+    then(message).isNotNull();
+    then(message.getHeaders()).containsKeys(TRACE_ID_HEADER, SPAN_ID_HEADER);
+    then(mockTracer.finishedSpans()).hasSize(1);
+  }
+
+  @Test
+  public void shouldCloseSpanWhenExceptionOccurred() {
+    try {
+      messagingTemplate.send(MessageBuilder.withPayload("hi")
+          .setHeader(THROW_EXCEPTION_HEADER, true)
+          .build());
+      fail("Exception should occur");
+    } catch (RuntimeException ignored) {
+      // Expected exception
+    }
+
+    then(message).isNotNull();
+    then(mockTracer.finishedSpans()).hasSize(1);
+    MockSpan span = mockTracer.finishedSpans()
+        .get(0);
+    then(span.logEntries()).hasSize(3);
+    then(span.logEntries()
+        .get(0)
+        .fields()).containsOnlyKeys("event");
+    then(span.logEntries()
+        .get(0)
+        .fields()
+        .get("event")).isEqualTo(Events.CLIENT_SEND);
+    then(span.logEntries()
+        .get(1)
+        .fields()).containsOnlyKeys("event");
+    then(span.logEntries()
+        .get(1)
+        .fields()
+        .get("event")).isEqualTo(Events.CLIENT_RECEIVE);
+    then(span.logEntries()
+        .get(2)
+        .fields()).containsOnlyKeys("error");
+    then(span.logEntries()
+        .get(2)
+        .fields()
+        .get("error")).isEqualTo("A terrible exception has occurred");
+  }
+
+  @Test
+  public void shouldLogClientReceivedClientSentEventWhenTheMessageIsSentAndReceived() {
+    tracedChannel.send(MessageBuilder.withPayload("hi")
+        .build());
+
+    then(mockTracer.finishedSpans()).hasSize(1);
+    MockSpan span = mockTracer.finishedSpans()
+        .get(0);
+    then(span.logEntries()).hasSize(2);
+
+    then(span.logEntries()
+        .get(0)
+        .fields()).containsOnlyKeys("event");
+    then(span.logEntries()
+        .get(0)
+        .fields()
+        .get("event")).isEqualTo(Events.CLIENT_SEND);
+    then(span.logEntries()
+        .get(1)
+        .fields()).containsOnlyKeys("event");
+    then(span.logEntries()
+        .get(1)
+        .fields()
+        .get("event")).isEqualTo(Events.CLIENT_RECEIVE);
+  }
+
+  @Test
+  public void shouldLogServerReceivedServerSentEventWhenTheMessageIsPropagatedToTheNextListener() {
+    tracedChannel.send(MessageBuilder.withPayload("hi")
+        .setHeader(Headers.MESSAGE_SENT_FROM_CLIENT, true)
+        .build());
+
+    then(mockTracer.finishedSpans()).hasSize(1);
+    MockSpan span = mockTracer.finishedSpans()
+        .get(0);
+    then(span.logEntries()).hasSize(2);
+
+    then(span.logEntries()
+        .get(0)
+        .fields()).containsOnlyKeys("event");
+    then(span.logEntries()
+        .get(0)
+        .fields()
+        .get("event")).isEqualTo(Events.SERVER_RECEIVE);
+    then(span.logEntries()
+        .get(1)
+        .fields()).containsOnlyKeys("event");
+    then(span.logEntries()
+        .get(1)
+        .fields()
+        .get("event")).isEqualTo(Events.SERVER_SEND);
+  }
+
+  @Test
+  @Ignore // TODO patterns are not yet supported
+  public void shouldNotTraceIgnoredChannel() {
+
+  }
+
+  @Test
+  @Ignore // TODO channel name limit is not yet supported
+  public void downgrades128bitIdsByDroppingHighBits() {
+
+  }
+
+  @Test
+  @Ignore // TODO header sanitation is not yet supported
+  public void shouldNotBreakWhenInvalidHeadersAreSent() {
+
+  }
+
+  @Configuration
+  @EnableAutoConfiguration
+  static class App {
+
+    @Bean
+    public ThreadLocalActiveSpanSource threadLocalActiveSpanSource() {
+      return new ThreadLocalActiveSpanSource();
+    }
+
+    @Bean
+    public MockTracer mockTracer(ThreadLocalActiveSpanSource threadLocalActiveSpanSource) {
+      return new MockTracer(threadLocalActiveSpanSource, MockTracer.Propagator.TEXT_MAP);
+    }
+
+    @Bean
+    public DirectChannel tracedChannel() {
+      return new DirectChannel();
+    }
+
+    @Bean
+    public PollableChannel pollableChannel() {
+      return new QueueChannel();
+    }
+
+    @Bean
+    public MessagingTemplate messagingTemplate() {
+      return new MessagingTemplate(tracedChannel());
+    }
+
+    @Bean
+    @GlobalChannelInterceptor
+    public OpenTracingChannelInterceptor openTracingChannelInterceptor(Tracer tracer) {
+      return new OpenTracingChannelInterceptor(tracer);
+    }
+
+  }
+
+}

--- a/opentracing-spring-messaging/src/test/java/io/opentracing/contrib/spring/integration/messaging/OpenTracingChannelInterceptorIT.java
+++ b/opentracing-spring-messaging/src/test/java/io/opentracing/contrib/spring/integration/messaging/OpenTracingChannelInterceptorIT.java
@@ -18,9 +18,11 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.fail;
 import static org.assertj.core.api.BDDAssertions.then;
 
+import io.opentracing.ActiveSpan;
 import io.opentracing.Tracer;
 import io.opentracing.mock.MockSpan;
 import io.opentracing.mock.MockTracer;
+import io.opentracing.tag.Tags;
 import io.opentracing.util.ThreadLocalActiveSpanSource;
 import org.junit.After;
 import org.junit.Before;
@@ -91,7 +93,6 @@ public class OpenTracingChannelInterceptorIT implements MessageHandler {
   @Before
   public void before() {
     tracedChannel.subscribe(this);
-    mockTracer.reset();
   }
 
   @After
@@ -162,31 +163,27 @@ public class OpenTracingChannelInterceptorIT implements MessageHandler {
   public void shouldCreateSpanWithActiveParent() {
     MockSpan parentSpan = mockTracer.buildSpan("http:testSendMessage")
         .start();
-    mockTracer.makeActive(parentSpan);
+    try (ActiveSpan activeSpan = mockTracer.makeActive(parentSpan)) {
+      tracedChannel.send(MessageBuilder.withPayload("hi")
+          .build());
+    }
 
-    tracedChannel.send(MessageBuilder.withPayload("hi")
-        .build());
     then(message).isNotNull();
     then(message.getHeaders()).containsKeys(TRACE_ID_HEADER, SPAN_ID_HEADER);
-    then(mockTracer.finishedSpans()).hasSize(1); // TODO because parent span is not finished
+    then(mockTracer.finishedSpans()).hasSize(2);
 
+    MockSpan interceptorSpan = mockTracer.finishedSpans().get(0);
+    then(interceptorSpan.context().traceId()).isEqualTo(parentSpan.context().traceId());
+    then(interceptorSpan.parentId()).isEqualTo(parentSpan.context().spanId());
+    then(interceptorSpan.operationName()).isEqualTo("send:tracedChannel");
+
+    // test inject
     Long traceId = Long.valueOf(message.getHeaders()
         .get(TRACE_ID_HEADER, String.class));
     Long spanId = Long.valueOf(message.getHeaders()
         .get(SPAN_ID_HEADER, String.class));
-
-    MockSpan.MockContext parentSpanContext = parentSpan.context();
-
-    then(traceId).isEqualTo(parentSpanContext.traceId());
-    then(spanId).isNotEqualTo(parentSpanContext.spanId());
-
-    MockSpan finishedSpan = mockTracer.finishedSpans()
-        .get(0);
-    then(finishedSpan.parentId()).isEqualTo(parentSpanContext.spanId());
-
-    MockSpan.MockContext finishedSpanContext = finishedSpan.context();
-    then(finishedSpanContext.traceId()).isEqualTo(traceId);
-    then(finishedSpanContext.spanId()).isEqualTo(spanId);
+    then(traceId).isEqualTo(parentSpan.context().traceId());
+    then(spanId).isEqualTo(interceptorSpan.context().spanId());
   }
 
   @Test
@@ -213,7 +210,7 @@ public class OpenTracingChannelInterceptorIT implements MessageHandler {
     then(mockTracer.finishedSpans()).hasSize(1);
     MockSpan span = mockTracer.finishedSpans()
         .get(0);
-    then(span.logEntries()).hasSize(3);
+    then(span.logEntries()).hasSize(2);
     then(span.logEntries()
         .get(0)
         .fields()).containsOnlyKeys("event");
@@ -228,13 +225,9 @@ public class OpenTracingChannelInterceptorIT implements MessageHandler {
         .get(1)
         .fields()
         .get("event")).isEqualTo(Events.CLIENT_RECEIVE);
-    then(span.logEntries()
-        .get(2)
-        .fields()).containsOnlyKeys("error");
-    then(span.logEntries()
-        .get(2)
-        .fields()
-        .get("error")).isEqualTo("A terrible exception has occurred");
+    then(span.tags()).hasSize(4);
+    then(span.tags().get(Tags.ERROR.getKey()))
+        .isEqualTo(true);
   }
 
   @Test
@@ -311,15 +304,9 @@ public class OpenTracingChannelInterceptorIT implements MessageHandler {
   @Configuration
   @EnableAutoConfiguration
   static class App {
-
     @Bean
-    public ThreadLocalActiveSpanSource threadLocalActiveSpanSource() {
-      return new ThreadLocalActiveSpanSource();
-    }
-
-    @Bean
-    public MockTracer mockTracer(ThreadLocalActiveSpanSource threadLocalActiveSpanSource) {
-      return new MockTracer(threadLocalActiveSpanSource, MockTracer.Propagator.TEXT_MAP);
+    public MockTracer mockTracer() {
+      return new MockTracer(new ThreadLocalActiveSpanSource(), MockTracer.Propagator.TEXT_MAP);
     }
 
     @Bean

--- a/opentracing-spring-messaging/src/test/java/io/opentracing/contrib/spring/integration/messaging/OpenTracingChannelInterceptorTest.java
+++ b/opentracing-spring-messaging/src/test/java/io/opentracing/contrib/spring/integration/messaging/OpenTracingChannelInterceptorTest.java
@@ -1,0 +1,229 @@
+/**
+ * Copyright 2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.opentracing.contrib.spring.integration.messaging;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.anyMap;
+import static org.mockito.Matchers.anyString;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.opentracing.ActiveSpan;
+import io.opentracing.SpanContext;
+import io.opentracing.Tracer;
+import io.opentracing.propagation.Format;
+import io.opentracing.tag.Tags;
+import java.util.Collections;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+import org.mockito.MockitoAnnotations;
+import org.springframework.integration.channel.AbstractMessageChannel;
+import org.springframework.messaging.Message;
+import org.springframework.messaging.MessageChannel;
+import org.springframework.messaging.support.MessageBuilder;
+
+/**
+ * @author <a href="mailto:gytis@redhat.com">Gytis Trikleris</a>
+ */
+public class OpenTracingChannelInterceptorTest {
+
+  @Mock
+  private Tracer mockTracer;
+
+  @Mock
+  private Tracer.SpanBuilder mockSpanBuilder;
+
+  @Mock
+  private ActiveSpan mockActiveSpan;
+
+  @Mock
+  private SpanContext mockSpanContext;
+
+  @Mock
+  private MessageChannel mockMessageChannel;
+
+  @Mock
+  private AbstractMessageChannel mockAbstractMessageChannel;
+
+  private Message<String> simpleMessage;
+
+  private OpenTracingChannelInterceptor interceptor;
+
+  @Before
+  public void before() {
+    MockitoAnnotations.initMocks(this);
+    when(mockTracer.buildSpan(anyString())).thenReturn(mockSpanBuilder);
+    when(mockSpanBuilder.asChildOf(any(SpanContext.class))).thenReturn(mockSpanBuilder);
+    when(mockSpanBuilder.startActive()).thenReturn(mockActiveSpan);
+    when(mockActiveSpan.context()).thenReturn(mockSpanContext);
+
+    interceptor = new OpenTracingChannelInterceptor(mockTracer);
+    simpleMessage = MessageBuilder.withPayload("test")
+        .build();
+  }
+
+  @Test
+  public void preSendShouldGetNameFromGenericChannel() {
+    interceptor.preSend(simpleMessage, mockMessageChannel);
+    verify(mockTracer).buildSpan(String.format("message:%s", mockMessageChannel.toString()));
+  }
+
+  @Test
+  public void preSendShouldGetNameFromAbstractMessageChannel() {
+    interceptor.preSend(simpleMessage, mockAbstractMessageChannel);
+    verify(mockAbstractMessageChannel, times(2)).getFullChannelName();
+  }
+
+  @Test
+  public void preSendShouldStartSpanForClientSentMessage() {
+    Message<?> message = interceptor.preSend(simpleMessage, mockMessageChannel);
+    assertThat(message.getPayload()).isEqualTo(simpleMessage.getPayload());
+    assertThat(message.getHeaders()).containsKey(Headers.MESSAGE_SENT_FROM_CLIENT);
+
+    verify(mockTracer).extract(eq(Format.Builtin.TEXT_MAP), any(MessageTextMap.class));
+    verify(mockTracer).buildSpan(String.format("message:%s", mockMessageChannel.toString()));
+    verify(mockSpanBuilder).asChildOf((SpanContext) null);
+    verify(mockSpanBuilder).startActive();
+    verify(mockActiveSpan).setTag(Tags.COMPONENT.getKey(), "spring-messaging");
+    verify(mockActiveSpan).setTag(Tags.MESSAGE_BUS_DESTINATION.getKey(), mockMessageChannel.toString());
+    verify(mockActiveSpan).setTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_PRODUCER);
+    verify(mockActiveSpan).log(Events.CLIENT_SEND);
+  }
+
+  @Test
+  public void preSendShouldStartSpanForServerReceivedMessage() {
+    Message<?> originalMessage = MessageBuilder.fromMessage(simpleMessage)
+        .setHeader(Headers.MESSAGE_SENT_FROM_CLIENT, true)
+        .build();
+    Message<?> message = interceptor.preSend(originalMessage, mockMessageChannel);
+    assertThat(message.getPayload()).isEqualTo(originalMessage.getPayload());
+
+    verify(mockTracer).extract(eq(Format.Builtin.TEXT_MAP), any(MessageTextMap.class));
+    verify(mockTracer).buildSpan(String.format("message:%s", mockMessageChannel.toString()));
+    verify(mockSpanBuilder).asChildOf((SpanContext) null);
+    verify(mockSpanBuilder).startActive();
+    verify(mockActiveSpan).setTag(Tags.COMPONENT.getKey(), "spring-messaging");
+    verify(mockActiveSpan).setTag(Tags.MESSAGE_BUS_DESTINATION.getKey(), mockMessageChannel.toString());
+    verify(mockActiveSpan).setTag(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_CONSUMER);
+    verify(mockActiveSpan).log(Events.SERVER_RECEIVE);
+  }
+
+  @Test
+  public void preSendShouldStartChildSpanFromCarrier() {
+    when(mockTracer.extract(eq(Format.Builtin.TEXT_MAP), any(MessageTextMap.class))).thenReturn(mockSpanContext);
+
+    interceptor.preSend(simpleMessage, mockMessageChannel);
+
+    verify(mockSpanBuilder).asChildOf(mockSpanContext);
+  }
+
+  @Test
+  public void afterSendCompletionShouldDoNothingWithoutSpan() {
+    interceptor.afterSendCompletion(null, null, true, null);
+
+    verify(mockTracer).activeSpan();
+    verify(mockActiveSpan, times(0)).log(anyString());
+  }
+
+  @Test
+  public void afterSendCompletionShouldFinishSpanForServerSendMessage() {
+    when(mockTracer.activeSpan()).thenReturn(mockActiveSpan);
+    when(mockActiveSpan.getBaggageItem(Events.SERVER_RECEIVE)).thenReturn(Events.SERVER_RECEIVE);
+
+    interceptor.afterSendCompletion(null, null, true, null);
+
+    verify(mockTracer).activeSpan();
+    verify(mockActiveSpan).log(Events.SERVER_SEND);
+    verify(mockActiveSpan, times(0)).log(anyMap());
+    verify(mockActiveSpan).close();
+  }
+
+  @Test
+  public void afterSendCompletionShouldFinishSpanForClientSendMessage() {
+    when(mockTracer.activeSpan()).thenReturn(mockActiveSpan);
+
+    interceptor.afterSendCompletion(null, null, true, null);
+
+    verify(mockTracer).activeSpan();
+    verify(mockActiveSpan).log(Events.CLIENT_RECEIVE);
+    verify(mockActiveSpan, times(0)).log(anyMap());
+    verify(mockActiveSpan).close();
+  }
+
+  @Test
+  public void afterSendCompletionShouldFinishSpanForException() {
+    when(mockTracer.activeSpan()).thenReturn(mockActiveSpan);
+
+    interceptor.afterSendCompletion(null, null, true, new Exception("test"));
+
+    verify(mockTracer).activeSpan();
+    verify(mockActiveSpan).log(Events.CLIENT_RECEIVE);
+    verify(mockActiveSpan).log(Collections.singletonMap(Events.ERROR, "test"));
+    verify(mockActiveSpan).close();
+  }
+
+  @Test
+  public void beforeHandleShouldDoNothingWithoutSpan() {
+    interceptor.beforeHandle(null, null, null);
+
+    verify(mockTracer).activeSpan();
+    verify(mockActiveSpan, times(0)).log(anyString());
+  }
+
+  @Test
+  public void beforeHandleShouldLogEvent() {
+    when(mockTracer.activeSpan()).thenReturn(mockActiveSpan);
+
+    interceptor.beforeHandle(null, null, null);
+
+    verify(mockActiveSpan).log(Events.SERVER_RECEIVE);
+  }
+
+  @Test
+  public void afterMessageHandledShouldDoNothingWithoutSpan() {
+    interceptor.afterMessageHandled(null, null, null, null);
+
+    verify(mockTracer).activeSpan();
+    verify(mockActiveSpan, times(0)).log(anyString());
+    verify(mockActiveSpan, times(0)).log(anyMap());
+  }
+
+  @Test
+  public void afterMessageHandledShouldLogEvent() {
+    when(mockTracer.activeSpan()).thenReturn(mockActiveSpan);
+
+    interceptor.afterMessageHandled(null, null, null, null);
+
+    verify(mockTracer).activeSpan();
+    verify(mockActiveSpan).log(Events.SERVER_SEND);
+    verify(mockActiveSpan, times(0)).log(anyMap());
+  }
+
+  @Test
+  public void afterMessageHandledShouldLogEventAndException() {
+    when(mockTracer.activeSpan()).thenReturn(mockActiveSpan);
+
+    interceptor.afterMessageHandled(null, null, null, new Exception("test"));
+
+    verify(mockTracer).activeSpan();
+    verify(mockActiveSpan).log(Events.SERVER_SEND);
+    verify(mockActiveSpan).log(Collections.singletonMap(Events.ERROR, "test"));
+  }
+
+}

--- a/pom.xml
+++ b/pom.xml
@@ -23,6 +23,7 @@
   <modules>
     <module>opentracing-spring-cloud</module>
     <module>opentracing-spring-cloud-starter</module>
+    <module>opentracing-spring-messaging</module>
   </modules>
   <packaging>pom</packaging>
 


### PR DESCRIPTION
Here's the initial code for the Spring Messaging tracing needed for Spring Cloud Stream and other bits that depend on Spring Messaging. This is the initial code which I've ported from Spring Cloud Sleuth including some of it's tests. 

You'll notice that there are still quite a few TODO comments in the code which I hope to complete in a next couple of days. Also, I'd like to refactor OpenTracingChannelInterceptor and MessageBuilderTextMap and also remove of the helper classes which hopefully won't be needed after refactor. However, I'm raising this pull request now in order to get some feedback if the integration is heading into a right direction.

Additionally, I also have a module to test this integration with Spring Cloud Stream, but I wasn't sure how to integrate it into this project, so not including it at the moment. Let me know if you have any ideas.