### PR TITLE
Integration tests with Artemis and Kafka binders

### DIFF
--- a/opentracing-spring-messaging-it/opentracing-spring-messaging-it-stream-artemis/pom.xml
+++ b/opentracing-spring-messaging-it/opentracing-spring-messaging-it-stream-artemis/pom.xml
@@ -1,0 +1,58 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2017 The OpenTracing Authors
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+    in compliance with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the License
+    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+    or implied. See the License for the specific language governing permissions and limitations under
+    the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+
+  <!-- Don't inherit from the parent to avoid Artemis version mismatch -->
+  <groupId>io.opentracing.contrib</groupId>
+  <artifactId>opentracing-spring-messaging-it-stream-artemis</artifactId>
+  <version>0.0.8-SNAPSHOT</version>
+
+  <properties>
+    <main.basedir>${project.basedir}/../..</main.basedir>
+
+    <maven.compiler.source>1.8</maven.compiler.source>
+    <maven.compiler.target>1.8</maven.compiler.target>
+    <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+
+    <version.me.snowdrop.spring-cloud-starter-stream-artemis>1.0.0.Alpha1</version.me.snowdrop.spring-cloud-starter-stream-artemis>
+    <version.org.apache.activemq>2.1.0</version.org.apache.activemq>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.opentracing.contrib</groupId>
+      <artifactId>opentracing-spring-messaging-it-stream-common</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>me.snowdrop</groupId>
+      <artifactId>spring-cloud-starter-stream-artemis</artifactId>
+      <version>${version.me.snowdrop.spring-cloud-starter-stream-artemis}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.apache.activemq</groupId>
+      <artifactId>artemis-jms-server</artifactId>
+      <version>${version.org.apache.activemq}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/opentracing-spring-messaging-it/opentracing-spring-messaging-it-stream-artemis/pom.xml
+++ b/opentracing-spring-messaging-it/opentracing-spring-messaging-it-stream-artemis/pom.xml
@@ -33,6 +33,7 @@
 
     <version.me.snowdrop.spring-cloud-starter-stream-artemis>1.0.0.Alpha1</version.me.snowdrop.spring-cloud-starter-stream-artemis>
     <version.org.apache.activemq>2.1.0</version.org.apache.activemq>
+    <version.org.springframework.boot>1.5.8.RELEASE</version.org.springframework.boot>
   </properties>
 
   <dependencies>
@@ -40,6 +41,18 @@
       <groupId>io.opentracing.contrib</groupId>
       <artifactId>opentracing-spring-messaging-it-stream-common</artifactId>
       <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.opentracing.contrib</groupId>
+      <artifactId>opentracing-spring-cloud-starter</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-websocket</artifactId>
+      <version>${version.org.springframework.boot}</version>
       <scope>test</scope>
     </dependency>
     <dependency>

--- a/opentracing-spring-messaging-it/opentracing-spring-messaging-it-stream-artemis/src/test/java/io/opentracing/contrib/spring/integration/messaging/ArtemisBinderTest.java
+++ b/opentracing-spring-messaging-it/opentracing-spring-messaging-it-stream-artemis/src/test/java/io/opentracing/contrib/spring/integration/messaging/ArtemisBinderTest.java
@@ -107,6 +107,8 @@ public class ArtemisBinderTest {
     assertThat(inputSpan.tags()).containsEntry(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_CONSUMER);
     assertThat(inputSpan.tags()).containsEntry(Tags.COMPONENT.getKey(), OpenTracingChannelInterceptor.COMPONENT_NAME);
     assertThat(inputSpan.tags()).containsEntry(Tags.MESSAGE_BUS_DESTINATION.getKey(), "input");
+
+    assertThat(outputSpan.startMicros()).isLessThanOrEqualTo(inputSpan.startMicros());
   }
 
   @Test

--- a/opentracing-spring-messaging-it/opentracing-spring-messaging-it-stream-artemis/src/test/java/io/opentracing/contrib/spring/integration/messaging/ArtemisBinderTest.java
+++ b/opentracing-spring-messaging-it/opentracing-spring-messaging-it-stream-artemis/src/test/java/io/opentracing/contrib/spring/integration/messaging/ArtemisBinderTest.java
@@ -1,0 +1,116 @@
+/**
+ * Copyright 2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.opentracing.contrib.spring.integration.messaging;
+
+import static io.opentracing.contrib.spring.integration.messaging.utils.SpanAssertions.assertEvents;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.Matchers.hasSize;
+
+import io.opentracing.mock.MockSpan;
+import io.opentracing.mock.MockTracer;
+import io.opentracing.tag.Tags;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.junit4.SpringRunner;
+
+/**
+ * @author <a href="mailto:gytis@redhat.com">Gytis Trikleris</a>
+ */
+@RunWith(SpringRunner.class)
+@SpringBootTest
+public class ArtemisBinderTest {
+
+  @Autowired
+  private Sender sender;
+
+  @Autowired
+  private Receiver receiver;
+
+  @Autowired
+  private MockTracer tracer;
+
+  @Before
+  public void before() {
+    receiver.clear();
+    tracer.reset();
+  }
+
+  /**
+   * Sleuth flow:
+   * 1. Processing message before sending it to the channel
+   * 2. Parent span is null
+   * 3. Name of the span will be [message:output]
+   * 4. Marking span with client send
+   * 5. Completed sending and current span is [Trace: 4730e0ce0c182eb9, Span: 4730e0ce0c182eb9, Parent: null,
+   * exportable:false]
+   * 6. Marking span with client received
+   * 7. Closing messaging span [Trace: 4730e0ce0c182eb9, Span: 4730e0ce0c182eb9, Parent: null, exportable:false]
+   * 8. Messaging span [Trace: 4730e0ce0c182eb9, Span: 4730e0ce0c182eb9, Parent: null, exportable:false] successfully
+   * closed
+   * 9. Processing message before sending it to the channel
+   * 10. Parent span is [Trace: 4730e0ce0c182eb9, Span: 4730e0ce0c182eb9, Parent: null, exportable:false]
+   * 11. Name of the span will be [message:input]
+   * 12. Completed sending and current span is [Trace: 4730e0ce0c182eb9, Span: c8a8655bb5216278, Parent:
+   * 4730e0ce0c182eb9, exportable:false]
+   * 13. Marking span with server send
+   * 14. Closing messaging span [Trace: 4730e0ce0c182eb9, Span: c8a8655bb5216278, Parent: 4730e0ce0c182eb9,
+   * exportable:false]
+   * 15. Messaging span [Trace: 4730e0ce0c182eb9, Span: c8a8655bb5216278, Parent: 4730e0ce0c182eb9, exportable:false]
+   * successfully closed
+   */
+  @Test
+  public void testFlowFromSourceToSink() {
+    sender.send("Ping");
+
+    await().atMost(5, SECONDS)
+        .until(receiver::getReceivedMessages, hasSize(1));
+
+    List<MockSpan> finishedSpans = tracer.finishedSpans();
+    assertThat(finishedSpans).hasSize(2);
+
+    MockSpan outputSpan = getSpanByOperation("send:output");
+    assertThat(outputSpan.parentId()).isEqualTo(0);
+    assertEvents(outputSpan, Arrays.asList(Events.CLIENT_SEND, Events.CLIENT_RECEIVE));
+    assertThat(outputSpan.tags()).hasSize(3);
+    assertThat(outputSpan.tags()).containsEntry(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_PRODUCER);
+    assertThat(outputSpan.tags()).containsEntry(Tags.COMPONENT.getKey(), OpenTracingChannelInterceptor.COMPONENT_NAME);
+    assertThat(outputSpan.tags()).containsEntry(Tags.MESSAGE_BUS_DESTINATION.getKey(), "output");
+
+    MockSpan inputSpan = getSpanByOperation("receive:input");
+    assertThat(inputSpan.parentId()).isEqualTo(outputSpan.context().spanId());
+    assertEvents(inputSpan, Arrays.asList(Events.SERVER_RECEIVE, Events.SERVER_SEND));
+    assertThat(inputSpan.tags()).hasSize(3);
+    assertThat(inputSpan.tags()).containsEntry(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_CONSUMER);
+    assertThat(inputSpan.tags()).containsEntry(Tags.COMPONENT.getKey(), OpenTracingChannelInterceptor.COMPONENT_NAME);
+    assertThat(inputSpan.tags()).containsEntry(Tags.MESSAGE_BUS_DESTINATION.getKey(), "input");
+  }
+
+  private MockSpan getSpanByOperation(String operationName) {
+    return tracer.finishedSpans()
+        .stream()
+        .filter(s -> operationName.equals(s.operationName()))
+        .findAny()
+        .orElseThrow(
+            () -> new RuntimeException(String.format("Span for operation '%s' doesn't exist", operationName)));
+  }
+
+}

--- a/opentracing-spring-messaging-it/opentracing-spring-messaging-it-stream-artemis/src/test/resources/application.yml
+++ b/opentracing-spring-messaging-it/opentracing-spring-messaging-it-stream-artemis/src/test/resources/application.yml
@@ -1,0 +1,11 @@
+spring:
+  cloud:
+    stream:
+      artemis:
+        binder:
+          transport: org.apache.activemq.artemis.core.remoting.impl.invm.InVMConnectorFactory
+      bindings:
+        input:
+          destination: testDestination
+        output:
+          destination: testDestination

--- a/opentracing-spring-messaging-it/opentracing-spring-messaging-it-stream-common/pom.xml
+++ b/opentracing-spring-messaging-it/opentracing-spring-messaging-it-stream-common/pom.xml
@@ -59,6 +59,7 @@
     <dependency>
       <groupId>org.awaitility</groupId>
       <artifactId>awaitility</artifactId>
+      <version>${version.org.awaitility-awaitility}</version>
     </dependency>
   </dependencies>
 </project>

--- a/opentracing-spring-messaging-it/opentracing-spring-messaging-it-stream-common/pom.xml
+++ b/opentracing-spring-messaging-it/opentracing-spring-messaging-it-stream-common/pom.xml
@@ -1,0 +1,64 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2017 The OpenTracing Authors
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+    in compliance with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the License
+    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+    or implied. See the License for the specific language governing permissions and limitations under
+    the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>opentracing-spring-messaging-it</artifactId>
+    <groupId>io.opentracing.contrib</groupId>
+    <version>0.0.8-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>opentracing-spring-messaging-it-stream-common</artifactId>
+
+  <properties>
+    <main.basedir>${project.basedir}/../..</main.basedir>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.opentracing.contrib</groupId>
+      <artifactId>opentracing-spring-messaging</artifactId>
+      <version>${project.version}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.opentracing</groupId>
+      <artifactId>opentracing-api</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.opentracing</groupId>
+      <artifactId>opentracing-mock</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.opentracing</groupId>
+      <artifactId>opentracing-util</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.cloud</groupId>
+      <artifactId>spring-cloud-stream</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.awaitility</groupId>
+      <artifactId>awaitility</artifactId>
+    </dependency>
+  </dependencies>
+</project>

--- a/opentracing-spring-messaging-it/opentracing-spring-messaging-it-stream-common/src/main/java/io/opentracing/contrib/spring/integration/messaging/Receiver.java
+++ b/opentracing-spring-messaging-it/opentracing-spring-messaging-it-stream-common/src/main/java/io/opentracing/contrib/spring/integration/messaging/Receiver.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright 2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.opentracing.contrib.spring.integration.messaging;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.springframework.cloud.stream.annotation.EnableBinding;
+import org.springframework.cloud.stream.annotation.StreamListener;
+import org.springframework.cloud.stream.messaging.Sink;
+import org.springframework.messaging.Message;
+
+/**
+ * @author <a href="mailto:gytis@redhat.com">Gytis Trikleris</a>
+ */
+@EnableBinding(Sink.class)
+public class Receiver {
+
+  private final List<Message> receivedMessages = new ArrayList<>();
+
+  @StreamListener(Sink.INPUT)
+  public void receive(Message message) {
+    receivedMessages.add(message);
+  }
+
+  public List<Message> getReceivedMessages() {
+    return receivedMessages;
+  }
+
+  public void clear() {
+    receivedMessages.clear();
+  }
+
+}

--- a/opentracing-spring-messaging-it/opentracing-spring-messaging-it-stream-common/src/main/java/io/opentracing/contrib/spring/integration/messaging/Sender.java
+++ b/opentracing-spring-messaging-it/opentracing-spring-messaging-it-stream-common/src/main/java/io/opentracing/contrib/spring/integration/messaging/Sender.java
@@ -1,0 +1,43 @@
+/**
+ * Copyright 2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.opentracing.contrib.spring.integration.messaging;
+
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.cloud.stream.annotation.EnableBinding;
+import org.springframework.cloud.stream.messaging.Source;
+import org.springframework.integration.support.MessageBuilder;
+import org.springframework.messaging.Message;
+
+/**
+ * @author <a href="mailto:gytis@redhat.com">Gytis Trikleris</a>
+ */
+@EnableBinding(Source.class)
+public class Sender {
+
+  private final Source source;
+
+  @Autowired
+  public Sender(Source source) {
+    this.source = source;
+  }
+
+  public void send(Object payload) {
+    Message message = MessageBuilder.withPayload(payload)
+            .build();
+    source.output()
+            .send(message);
+  }
+
+}

--- a/opentracing-spring-messaging-it/opentracing-spring-messaging-it-stream-common/src/main/java/io/opentracing/contrib/spring/integration/messaging/StreamApplication.java
+++ b/opentracing-spring-messaging-it/opentracing-spring-messaging-it-stream-common/src/main/java/io/opentracing/contrib/spring/integration/messaging/StreamApplication.java
@@ -1,0 +1,51 @@
+/**
+ * Copyright 2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.opentracing.contrib.spring.integration.messaging;
+
+import io.opentracing.Tracer;
+import io.opentracing.mock.MockTracer;
+import io.opentracing.util.ThreadLocalActiveSpanSource;
+import org.springframework.boot.SpringApplication;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.context.annotation.Bean;
+import org.springframework.integration.config.GlobalChannelInterceptor;
+
+/**
+ * @author <a href="mailto:gytis@redhat.com">Gytis Trikleris</a>
+ */
+@SpringBootApplication
+public class StreamApplication {
+
+  public static void main(String... args) {
+    SpringApplication.run(StreamApplication.class, args);
+  }
+
+  @Bean
+  public ThreadLocalActiveSpanSource threadLocalActiveSpanSource() {
+    return new ThreadLocalActiveSpanSource();
+  }
+
+  @Bean
+  public MockTracer mockTracer() {
+    return new MockTracer(new ThreadLocalActiveSpanSource(), MockTracer.Propagator.TEXT_MAP);
+  }
+
+  @Bean
+  @GlobalChannelInterceptor
+  public OpenTracingChannelInterceptor openTracingChannelInterceptor(Tracer tracer) {
+    return new OpenTracingChannelInterceptor(tracer);
+  }
+
+}

--- a/opentracing-spring-messaging-it/opentracing-spring-messaging-it-stream-common/src/main/java/io/opentracing/contrib/spring/integration/messaging/utils/SpanAssertions.java
+++ b/opentracing-spring-messaging-it/opentracing-spring-messaging-it-stream-common/src/main/java/io/opentracing/contrib/spring/integration/messaging/utils/SpanAssertions.java
@@ -1,0 +1,44 @@
+/**
+ * Copyright 2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.opentracing.contrib.spring.integration.messaging.utils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.opentracing.mock.MockSpan;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * @author <a href="mailto:gytis@redhat.com">Gytis Trikleris</a>
+ */
+public interface SpanAssertions {
+
+  static void assertEvents(MockSpan span, List<String> expectedEvents) {
+    List<String> actualEvents = span.logEntries()
+            .stream()
+            .map(MockSpan.LogEntry::fields)
+            .map(Map::entrySet)
+            .flatMap(Set::stream)
+            .filter(e -> "event".equals(e.getKey()))
+            .map(Map.Entry::getValue)
+            .map(String::valueOf)
+            .collect(Collectors.toList());
+
+    assertThat(actualEvents).containsAll(expectedEvents);
+  }
+
+}

--- a/opentracing-spring-messaging-it/opentracing-spring-messaging-it-stream-kafka/pom.xml
+++ b/opentracing-spring-messaging-it/opentracing-spring-messaging-it-stream-kafka/pom.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2017 The OpenTracing Authors
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+    in compliance with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the License
+    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+    or implied. See the License for the specific language governing permissions and limitations under
+    the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>io.opentracing.contrib</groupId>
+    <artifactId>opentracing-spring-messaging-it</artifactId>
+    <version>0.0.8-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>opentracing-spring-messaging-it-stream-kafka</artifactId>
+
+  <properties>
+    <main.basedir>${project.basedir}/../..</main.basedir>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.opentracing.contrib</groupId>
+      <artifactId>opentracing-spring-messaging-it-stream-common</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.cloud</groupId>
+      <artifactId>spring-cloud-stream-binder-kafka</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.kafka</groupId>
+      <artifactId>spring-kafka-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/opentracing-spring-messaging-it/opentracing-spring-messaging-it-stream-kafka/src/test/java/io/opentracing/contrib/spring/integration/messaging/KafkaBinderTest.java
+++ b/opentracing-spring-messaging-it/opentracing-spring-messaging-it-stream-kafka/src/test/java/io/opentracing/contrib/spring/integration/messaging/KafkaBinderTest.java
@@ -1,0 +1,122 @@
+/**
+ * Copyright 2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.opentracing.contrib.spring.integration.messaging;
+
+import static io.opentracing.contrib.spring.integration.messaging.utils.SpanAssertions.assertEvents;
+import static java.util.concurrent.TimeUnit.SECONDS;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
+import static org.hamcrest.Matchers.hasSize;
+
+import io.opentracing.mock.MockSpan;
+import io.opentracing.mock.MockTracer;
+import io.opentracing.tag.Tags;
+import java.util.Arrays;
+import java.util.List;
+import org.junit.BeforeClass;
+import org.junit.ClassRule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.kafka.test.rule.KafkaEmbedded;
+import org.springframework.test.context.junit4.SpringRunner;
+
+/**
+ * @author <a href="mailto:gytis@redhat.com">Gytis Trikleris</a>
+ */
+@RunWith(SpringRunner.class)
+@SpringBootTest
+public class KafkaBinderTest {
+
+  @ClassRule
+  public static KafkaEmbedded embeddedKafka = new KafkaEmbedded(1);
+
+  @Autowired
+  private Sender sender;
+
+  @Autowired
+  private Receiver receiver;
+
+  @Autowired
+  private MockTracer tracer;
+
+  @BeforeClass
+  public static void setup() {
+    System.setProperty("spring.kafka.bootstrap-servers", embeddedKafka.getBrokersAsString());
+    System.setProperty("spring.cloud.stream.kafka.binder.zkNodes", embeddedKafka.getZookeeperConnectionString());
+  }
+
+  /**
+   * Sleuth flow:
+   * 1. Processing message before sending it to the channel
+   * 2. Parent span is null
+   * 3. Name of the span will be [message:output]
+   * 4. Marking span with client send
+   * 5. Completed sending and current span is [Trace: 91aeac586e6d3a99, Span: 91aeac586e6d3a99, Parent: null,
+   * exportable:false]
+   * 6. Marking span with client received
+   * 7. Closing messaging span [Trace: 91aeac586e6d3a99, Span: 91aeac586e6d3a99, Parent: null, exportable:false]
+   * 8. Stopped span: [Trace: 91aeac586e6d3a99, Span: 91aeac586e6d3a99, Parent: null, exportable:false]
+   * 9. Messaging span [Trace: 91aeac586e6d3a99, Span: 91aeac586e6d3a99, Parent: null, exportable:false]
+   * successfully closed
+   * 10. Processing message before sending it to the channel
+   * 11. Parent span is null
+   * 12. Name of the span will be [message:input]
+   * 13. Marking span with client send
+   * 14. Completed sending and current span is [Trace: 75f4f6f504ce8a9a, Span: 75f4f6f504ce8a9a, Parent: null,
+   * exportable:false]
+   * 15. Marking span with client received
+   * 16. Closing messaging span [Trace: 75f4f6f504ce8a9a, Span: 75f4f6f504ce8a9a, Parent: null, exportable:false]
+   * 17. Messaging span [Trace: 75f4f6f504ce8a9a, Span: 75f4f6f504ce8a9a, Parent: null, exportable:false]
+   * successfully closed
+   */
+  @Test
+  public void testFlowFromSourceToSink() {
+    sender.send("Ping");
+
+    await().atMost(5, SECONDS)
+        .until(receiver::getReceivedMessages, hasSize(1));
+
+    List<MockSpan> finishedSpans = tracer.finishedSpans();
+    assertThat(finishedSpans).hasSize(2);
+
+    MockSpan outputSpan = getSpanByOperation("send:output");
+    assertThat(outputSpan.parentId()).isEqualTo(0);
+    assertEvents(outputSpan, Arrays.asList(Events.CLIENT_SEND, Events.CLIENT_RECEIVE));
+    assertThat(outputSpan.tags()).hasSize(3);
+    assertThat(outputSpan.tags()).containsEntry(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_PRODUCER);
+    assertThat(outputSpan.tags()).containsEntry(Tags.COMPONENT.getKey(), OpenTracingChannelInterceptor.COMPONENT_NAME);
+    assertThat(outputSpan.tags()).containsEntry(Tags.MESSAGE_BUS_DESTINATION.getKey(), "output");
+
+    MockSpan inputSpan = getSpanByOperation("send:input");
+    assertThat(inputSpan.parentId()).isEqualTo(0);
+    assertEvents(inputSpan, Arrays.asList(Events.CLIENT_SEND, Events.CLIENT_RECEIVE));
+    assertThat(inputSpan.tags()).hasSize(3);
+    assertThat(inputSpan.tags()).containsEntry(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_PRODUCER);
+    assertThat(inputSpan.tags()).containsEntry(Tags.COMPONENT.getKey(), OpenTracingChannelInterceptor.COMPONENT_NAME);
+    assertThat(inputSpan.tags()).containsEntry(Tags.MESSAGE_BUS_DESTINATION.getKey(), "input");
+  }
+
+  private MockSpan getSpanByOperation(String operationName) {
+    return tracer.finishedSpans()
+        .stream()
+        .filter(s -> operationName.equals(s.operationName()))
+        .findAny()
+        .orElseThrow(
+            () -> new RuntimeException(String.format("Span for operation '%s' doesn't exist", operationName)));
+  }
+
+}

--- a/opentracing-spring-messaging-it/opentracing-spring-messaging-it-stream-kafka/src/test/java/io/opentracing/contrib/spring/integration/messaging/KafkaBinderTest.java
+++ b/opentracing-spring-messaging-it/opentracing-spring-messaging-it-stream-kafka/src/test/java/io/opentracing/contrib/spring/integration/messaging/KafkaBinderTest.java
@@ -108,6 +108,8 @@ public class KafkaBinderTest {
     assertThat(inputSpan.tags()).containsEntry(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_PRODUCER);
     assertThat(inputSpan.tags()).containsEntry(Tags.COMPONENT.getKey(), OpenTracingChannelInterceptor.COMPONENT_NAME);
     assertThat(inputSpan.tags()).containsEntry(Tags.MESSAGE_BUS_DESTINATION.getKey(), "input");
+
+    assertThat(outputSpan.startMicros()).isLessThanOrEqualTo(inputSpan.startMicros());
   }
 
   private MockSpan getSpanByOperation(String operationName) {

--- a/opentracing-spring-messaging-it/opentracing-spring-messaging-it-stream-kafka/src/test/resources/application.yml
+++ b/opentracing-spring-messaging-it/opentracing-spring-messaging-it-stream-kafka/src/test/resources/application.yml
@@ -1,0 +1,12 @@
+spring:
+  kafka:
+    consumer:
+      group-id: testGroup
+  cloud:
+    stream:
+      bindings:
+        input:
+          destination: testDestination
+          group: testGroup
+        output:
+          destination: testDestination

--- a/opentracing-spring-messaging-it/opentracing-spring-messaging-it-stream-rabbit/pom.xml
+++ b/opentracing-spring-messaging-it/opentracing-spring-messaging-it-stream-rabbit/pom.xml
@@ -1,0 +1,51 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2017 The OpenTracing Authors
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+    in compliance with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the License
+    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+    or implied. See the License for the specific language governing permissions and limitations under
+    the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <groupId>io.opentracing.contrib</groupId>
+    <artifactId>opentracing-spring-messaging-it</artifactId>
+    <version>0.0.8-SNAPSHOT</version>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>opentracing-spring-messaging-it-stream-rabbit</artifactId>
+
+  <properties>
+    <main.basedir>${project.basedir}/../..</main.basedir>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.opentracing.contrib</groupId>
+      <artifactId>opentracing-spring-messaging-it-stream-common</artifactId>
+      <version>${project.version}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.cloud</groupId>
+      <artifactId>spring-cloud-stream-binder-rabbit</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-amqp</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/opentracing-spring-messaging-it/opentracing-spring-messaging-it-stream-rabbit/src/test/java/io/opentracing/contrib/spring/integration/messaging/RabbitBinderTest.java
+++ b/opentracing-spring-messaging-it/opentracing-spring-messaging-it-stream-rabbit/src/test/java/io/opentracing/contrib/spring/integration/messaging/RabbitBinderTest.java
@@ -107,6 +107,8 @@ public class RabbitBinderTest {
     assertThat(inputSpan.tags()).containsEntry(Tags.SPAN_KIND.getKey(), Tags.SPAN_KIND_CONSUMER);
     assertThat(inputSpan.tags()).containsEntry(Tags.COMPONENT.getKey(), OpenTracingChannelInterceptor.COMPONENT_NAME);
     assertThat(inputSpan.tags()).containsEntry(Tags.MESSAGE_BUS_DESTINATION.getKey(), "input");
+
+    assertThat(outputSpan.startMicros()).isLessThanOrEqualTo(inputSpan.startMicros());
   }
 
   private MockSpan getSpanByOperation(String operationName) {

--- a/opentracing-spring-messaging-it/opentracing-spring-messaging-it-stream-rabbit/src/test/java/io/opentracing/contrib/spring/integration/messaging/RabbitBrokerRule.java
+++ b/opentracing-spring-messaging-it/opentracing-spring-messaging-it-stream-rabbit/src/test/java/io/opentracing/contrib/spring/integration/messaging/RabbitBrokerRule.java
@@ -1,0 +1,45 @@
+/**
+ * Copyright 2017 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.opentracing.contrib.spring.integration.messaging;
+
+import org.junit.AssumptionViolatedException;
+import org.junit.rules.MethodRule;
+import org.junit.runners.model.FrameworkMethod;
+import org.junit.runners.model.Statement;
+import org.springframework.amqp.AmqpException;
+import org.springframework.amqp.rabbit.connection.Connection;
+import org.springframework.amqp.rabbit.core.RabbitTemplate;
+
+public class RabbitBrokerRule implements MethodRule {
+
+  private final RabbitTemplate rabbitTemplate;
+
+  public RabbitBrokerRule(RabbitTemplate rabbitTemplate) {
+    this.rabbitTemplate = rabbitTemplate;
+  }
+
+  @Override
+  public Statement apply(Statement statement, FrameworkMethod frameworkMethod, Object o) {
+    try {
+      Connection connection = rabbitTemplate.getConnectionFactory().createConnection();
+      connection.close();
+    } catch (AmqpException e) {
+      throw new AssumptionViolatedException("Ignored because of not available RabbitMQ broker");
+    }
+
+    return statement;
+  }
+
+}

--- a/opentracing-spring-messaging-it/opentracing-spring-messaging-it-stream-rabbit/src/test/resources/application.yml
+++ b/opentracing-spring-messaging-it/opentracing-spring-messaging-it-stream-rabbit/src/test/resources/application.yml
@@ -1,0 +1,8 @@
+spring:
+  cloud:
+    stream:
+      bindings:
+        input:
+          destination: testDestination
+        output:
+          destination: testDestination

--- a/opentracing-spring-messaging-it/pom.xml
+++ b/opentracing-spring-messaging-it/pom.xml
@@ -57,6 +57,7 @@
   <modules>
     <module>opentracing-spring-messaging-it-stream-artemis</module>
     <module>opentracing-spring-messaging-it-stream-kafka</module>
+    <module>opentracing-spring-messaging-it-stream-rabbit</module>
     <module>opentracing-spring-messaging-it-stream-common</module>
   </modules>
 </project>

--- a/opentracing-spring-messaging-it/pom.xml
+++ b/opentracing-spring-messaging-it/pom.xml
@@ -1,0 +1,62 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2017 The OpenTracing Authors
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+    in compliance with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the License
+    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+    or implied. See the License for the specific language governing permissions and limitations under
+    the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>io.opentracing.contrib</groupId>
+    <artifactId>opentracing-spring-cloud-parent</artifactId>
+    <version>0.0.8-SNAPSHOT</version>
+  </parent>
+
+  <artifactId>opentracing-spring-messaging-it</artifactId>
+  <packaging>pom</packaging>
+
+  <properties>
+    <main.basedir>${project.basedir}/..</main.basedir>
+
+    <version.org.awaitility>3.0.0</version.org.awaitility>
+  </properties>
+
+  <dependencyManagement>
+    <dependencies>
+      <dependency>
+        <groupId>org.awaitility</groupId>
+        <artifactId>awaitility</artifactId>
+        <version>${version.org.awaitility}</version>
+      </dependency>
+    </dependencies>
+  </dependencyManagement>
+
+  <build>
+    <plugins>
+      <plugin>
+        <artifactId>maven-deploy-plugin</artifactId>
+        <version>${version.maven-deploy-plugin}</version>
+        <configuration>
+          <skip>true</skip>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+  <modules>
+    <module>opentracing-spring-messaging-it-stream-artemis</module>
+    <module>opentracing-spring-messaging-it-stream-kafka</module>
+    <module>opentracing-spring-messaging-it-stream-common</module>
+  </modules>
+</project>

--- a/opentracing-spring-messaging-it/pom.xml
+++ b/opentracing-spring-messaging-it/pom.xml
@@ -29,19 +29,7 @@
 
   <properties>
     <main.basedir>${project.basedir}/..</main.basedir>
-
-    <version.org.awaitility>3.0.0</version.org.awaitility>
   </properties>
-
-  <dependencyManagement>
-    <dependencies>
-      <dependency>
-        <groupId>org.awaitility</groupId>
-        <artifactId>awaitility</artifactId>
-        <version>${version.org.awaitility}</version>
-      </dependency>
-    </dependencies>
-  </dependencyManagement>
 
   <build>
     <plugins>

--- a/pom.xml
+++ b/pom.xml
@@ -24,6 +24,7 @@
     <module>opentracing-spring-cloud</module>
     <module>opentracing-spring-cloud-starter</module>
     <module>opentracing-spring-messaging</module>
+    <module>opentracing-spring-messaging-it</module>
   </modules>
   <packaging>pom</packaging>
 
@@ -265,6 +266,7 @@
             <exclude>**/*.factories</exclude>
             <exclude>**/ExecutorBeanPostProcessor.java</exclude>
             <exclude>**/TraceEnvironmentPostProcessor.java</exclude>
+            <exclude>**/test/resources/application.yml</exclude>
           </excludes>
         </configuration>
         <executions>


### PR DESCRIPTION
@pavolloffay here are the integration tests for Artemis and Kafka Spring Cloud Stream binders. They use the same setup with source and sink, however the created spans are different (see comments in the test classes for Sleuth flow).
This PR also includes the Spring Boot and Cloud update because otherwise the tests won't work. I'll rebase this PR once the versions upgrade is merged.

I have a couple of questions regarding the layout.
1. I had to create a separate submodules because different dependencies and autoconfigurations are needed. Is it OK to have it in the top level? 
2. Because of different versions in root pom.xml and the ones used by Artemis binder, I wasn't able to inherit parent in opentracing-spring-messaging-it-stream-artemis module. 

Maybe we should create a separate project to avoid issues above?
  