### PR TITLE
Fix javadoc and disable strict lint

### DIFF
--- a/opentracing-spring-cloud/src/main/java/io/opentracing/contrib/spring/cloud/async/TraceEnvironmentPostProcessor.java
+++ b/opentracing-spring-cloud/src/main/java/io/opentracing/contrib/spring/cloud/async/TraceEnvironmentPostProcessor.java
@@ -28,9 +28,9 @@ import org.springframework.core.env.PropertySource;
  *     <li>logging pattern level that prints trace information (e.g. trace ids)</li>
  *     <li>enables usage of subclass-based (CGLIB) proxies are to be created as opposed
  * to standard Java interface-based proxies</li>
- *     It's required for the tracing aspects like
- *     {@link io.opentracing.contrib.spring.cloud.async.TraceAsyncAspect}
  * </ul>
+ * It's required for the tracing aspects like
+ * {@link io.opentracing.contrib.spring.cloud.async.TraceAsyncAspect}
  *
  * @author Dave Syer
  * @author Pavol Loffay

--- a/opentracing-spring-cloud/src/main/java/io/opentracing/contrib/spring/cloud/async/TracedAsyncWebAspect.java
+++ b/opentracing-spring-cloud/src/main/java/io/opentracing/contrib/spring/cloud/async/TracedAsyncWebAspect.java
@@ -25,10 +25,14 @@ import org.springframework.web.context.request.async.WebAsyncTask;
 
 /**
  * this class adds tracing to all {@link org.springframework.stereotype.Controller} or {@link
- * org.springframework.web.bind.annotation.RestController} that has <ul> <li>public {@link
- * java.util.concurrent.Callable} methods</li> <li>public {@link org.springframework.web.context.request.async.WebAsyncTask}
- * methods</li> </ul> All those methods which will eventually have {@link Callable#call()} will be
- * wrapped with {@link io.opentracing.contrib.concurrent.TracedCallable} <p>
+ * org.springframework.web.bind.annotation.RestController} that has
+ * <ul>
+ *   <li>public {@link java.util.concurrent.Callable} methods</li>
+ *   <li>public {@link org.springframework.web.context.request.async.WebAsyncTask} methods</li>
+*  </ul>
+ *
+ *  All those methods which will eventually have {@link Callable#call()} will be
+ * wrapped with {@link io.opentracing.contrib.concurrent.TracedCallable}
  */
 @Aspect
 public class TracedAsyncWebAspect {

--- a/opentracing-spring-cloud/src/main/java/io/opentracing/contrib/spring/cloud/jdbc/JdbcAspect.java
+++ b/opentracing-spring-cloud/src/main/java/io/opentracing/contrib/spring/cloud/jdbc/JdbcAspect.java
@@ -35,6 +35,7 @@ public class JdbcAspect {
    *
    * @param pjp the intercepted join point
    * @return a new {@link TracingConnection} wrapping the result of the joint point
+   * @throws Throwable in case of wrong JDBC URL
    */
   @Around("execution(java.sql.Connection *.getConnection(..)) && target(javax.sql.DataSource)")
   public Object getConnection(final ProceedingJoinPoint pjp) throws Throwable {

--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
     <version.maven-release-plugin>2.5.3</version.maven-release-plugin>
     <version.maven-source-plugin>3.0.1</version.maven-source-plugin>
     <version.maven-surefire-plugin>2.20</version.maven-surefire-plugin>
-    <version.maven-javadoc-plugin>2.10.4</version.maven-javadoc-plugin>
+    <version.maven-javadoc-plugin>3.0.0</version.maven-javadoc-plugin>
     <version.maven-checkstyle-plugin>2.17</version.maven-checkstyle-plugin>
     <version.checkstyle>8.3</version.checkstyle>
     <version.io.takari-maven>0.3.4</version.io.takari-maven>
@@ -311,6 +311,8 @@
             <version>${version.maven-javadoc-plugin}</version>
             <configuration>
               <failOnError>false</failOnError>
+              <!-- disable strict lint: we don't document all params, throws statements.. -->
+              <doclint>none</doclint>
             </configuration>
             <executions>
               <execution>


### PR DESCRIPTION
Fixes errors for https://travis-ci.org/opentracing-contrib/java-spring-cloud/jobs/343308671#L3965. 

Note that the build didn't fail. 