### PR TITLE
Make WebSocketAutoConfiguration conditional on actual WebSocket classes

### DIFF
--- a/opentracing-spring-cloud/src/main/java/io/opentracing/contrib/spring/cloud/websocket/WebsocketAutoConfiguration.java
+++ b/opentracing-spring-cloud/src/main/java/io/opentracing/contrib/spring/cloud/websocket/WebsocketAutoConfiguration.java
@@ -23,13 +23,12 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.messaging.support.ChannelInterceptor;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurationSupport;
 
 @Configuration
 @ConditionalOnBean(Tracer.class)
 @AutoConfigureAfter(TracerAutoConfiguration.class)
-@ConditionalOnClass(ChannelInterceptor.class)
+@ConditionalOnClass(WebSocketMessageBrokerConfigurationSupport.class)
 @ConditionalOnProperty(name = "opentracing.spring.cloud.websocket.enabled", havingValue = "true", matchIfMissing = true)
 public class WebsocketAutoConfiguration {
 


### PR DESCRIPTION
Hello,

I've found issue with the `WebSocketAutoConfiguration`. Currently it's conditional on a class from spring-messaging library, which we do have in our project, but we don't have the spring-websocket library and so this causes an issue mentioned in #106.

Or perhaps, we should include both classes in the condition? Let me know, thanks!