### PR TITLE
Added spring-boot-configuration-processor to jaeger starter

### DIFF
--- a/opentracing-spring-cloud-starter-jaeger/pom.xml
+++ b/opentracing-spring-cloud-starter-jaeger/pom.xml
@@ -44,6 +44,12 @@
 
     <dependency>
       <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-configuration-processor</artifactId>
+      <optional>true</optional>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>
     </dependency>


### PR DESCRIPTION
I've added missing spring-boot-configuration-processor to generate properly property metadata for jaeger starter.

Also I've fixed property `opentracing.jaeger.enableB3Propagation` name in condition.
>Use the dashed notation to specify each property, that is all lower case with a "-" to separate words (e.g. {@code my-long-property}).