### PR TITLE
#118 Upgrading org.springframework.boot version to 1.5.11.RELEASE

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
     <version.io.github.openfeign.opentracing>0.1.0</version.io.github.openfeign.opentracing>
     <!-- spring-boot-starter-parent is a module of spring-boot-dependencies
         https://github.com/spring-projects/spring-boot/blob/master/spring-boot-starters/spring-boot-starter-parent/pom.xml -->
-    <version.org.springframework.boot>1.5.8.RELEASE</version.org.springframework.boot>
+    <version.org.springframework.boot>1.5.11.RELEASE</version.org.springframework.boot>
     <version.org.springframework.cloud-spring-cloud-dependencies>Dalston.SR4</version.org.springframework.cloud-spring-cloud-dependencies>
     <version.org.awaitility-awaitility>3.0.0</version.org.awaitility-awaitility>
 


### PR DESCRIPTION
There is a security vulnerability in Spring Messaging (https://pivotal.io/security/cve-2018-1270)
that requires an upgrade to the most recent version of Spring Framework. This
commit upgrades Spring Boot to 1.5.11.RELEASE which depends on the fixed version
of spring.

Signed-off-by: Nate Hart <nhart@tableau.com>