### PR TITLE
Renamed property opentracing.jaeger.enableB3Propagation

### DIFF
--- a/opentracing-spring-cloud-starter-jaeger/src/main/java/io/opentracing/contrib/spring/cloud/starter/jaeger/JaegerAutoConfiguration.java
+++ b/opentracing-spring-cloud-starter-jaeger/src/main/java/io/opentracing/contrib/spring/cloud/starter/jaeger/JaegerAutoConfiguration.java
@@ -155,7 +155,7 @@ public class JaegerAutoConfiguration {
     return new NoopMetricsFactory();
   }
 
-  @ConditionalOnProperty(value = "opentracing.jaeger.enableB3Propagation", havingValue = "true")
+  @ConditionalOnProperty(value = "opentracing.jaeger.enable-b3-propagation", havingValue = "true")
   @Bean
   public TracerBuilderCustomizer b3CodecJaegerTracerCustomizer() {
     return new B3CodecTracerBuilderCustomizer();

--- a/opentracing-spring-cloud-starter-jaeger/src/test/java/io/opentracing/contrib/spring/cloud/starter/jaeger/customizer/JaegerTracerB3CustomerizerDisabledSpringTest.java
+++ b/opentracing-spring-cloud-starter-jaeger/src/test/java/io/opentracing/contrib/spring/cloud/starter/jaeger/customizer/JaegerTracerB3CustomerizerDisabledSpringTest.java
@@ -27,7 +27,7 @@ import org.springframework.test.context.TestPropertySource;
 @TestPropertySource(
     properties = {
         "spring.main.banner-mode=off",
-        "opentracing.jaeger.enableB3Propagation=false"
+        "opentracing.jaeger.enable-b3-propagation=false"
     }
 )
 public class JaegerTracerB3CustomerizerDisabledSpringTest extends AbstractTracerSpringTest {

--- a/opentracing-spring-cloud-starter-jaeger/src/test/java/io/opentracing/contrib/spring/cloud/starter/jaeger/customizer/JaegerTracerB3CustomerizerEnabledSpringTest.java
+++ b/opentracing-spring-cloud-starter-jaeger/src/test/java/io/opentracing/contrib/spring/cloud/starter/jaeger/customizer/JaegerTracerB3CustomerizerEnabledSpringTest.java
@@ -27,7 +27,7 @@ import org.springframework.test.context.TestPropertySource;
 @TestPropertySource(
     properties = {
         "spring.main.banner-mode=off",
-        "opentracing.jaeger.enableB3Propagation=true"
+        "opentracing.jaeger.enable-b3-propagation=true"
     }
 )
 public class JaegerTracerB3CustomerizerEnabledSpringTest extends AbstractTracerSpringTest {


### PR DESCRIPTION
Renamed `opentracing.jaeger.enableB3Propagation` to `opentracing.jaeger.enable-b3-propagation`, which conforms to Spring Boot standards and requirements.

This is excerpt from javadoc of `@ConditionalOnProperty.name`:
> Use the dashed notation to specify each property, that is all lower case with a "-"
> to separate words (e.g. {@code my-long-property}).

Tricky part is, that this on its own is a breaking change for Spring Boot 1.x. Non-breaking for Spring Boot 2.x:
Spring Boot 1.x has a bit illogical property resolution, property `enable-b3-propagation` is match by both `enable-b3-propagation` and `enableB3Propagation`. But `enableB3Propagation` is matched only by `enableB3Propagation`. This goes against its docs.
Spring Boot 2.x works a bit other way around, all properties are normalized to kebab-case, `enable-b3-propagation` is matched for any input format. When `enableB3Propagation` is used in condition, it is not matched by `enable-b3-propagation` input format. 

So, we either break possible current configurations (if they use `opentracing.jaeger.enableB3Propagation` on Spring Boot 1.x), and fix it for future SB versions, including current 2.x. 
Or, we keep it as it is, which partially breaks 2.x (it has to be configured with exactly `opentracing.jaeger.enableB3Propagation` and I'm not sure if env-property will work at all).
Note that 1.5.x will eventually come to EOL, now that we have new major release.

There might still be middle-ground, like duplicate bean definition with different conditions, one matching legacy property format for 2.x and still working with 1.x.