### PR TITLE
Jaeger test fixes

### DIFF
--- a/opentracing-spring-cloud-starter-jaeger/src/test/java/io/opentracing/contrib/spring/cloud/starter/jaeger/AbstractSenderSpringTest.java
+++ b/opentracing-spring-cloud-starter-jaeger/src/test/java/io/opentracing/contrib/spring/cloud/starter/jaeger/AbstractSenderSpringTest.java
@@ -16,6 +16,8 @@ package io.opentracing.contrib.spring.cloud.starter.jaeger;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.uber.jaeger.reporters.CompositeReporter;
+import com.uber.jaeger.reporters.RemoteReporter;
+import org.assertj.core.api.Condition;
 
 public abstract class AbstractSenderSpringTest extends AbstractTracerSpringTest {
 
@@ -28,6 +30,12 @@ public abstract class AbstractSenderSpringTest extends AbstractTracerSpringTest 
     assertThat(getTracer())
         .extracting("reporter")
         .flatExtracting("reporters")
+        .filteredOn(new Condition<Object>() {
+          @Override
+          public boolean matches(Object value) {
+            return value.getClass().equals(RemoteReporter.class);
+          }
+        })
         .extracting("sender")
         .extracting("class")
         .containsExactly(senderClass);

--- a/opentracing-spring-cloud-starter-jaeger/src/test/java/io/opentracing/contrib/spring/cloud/starter/jaeger/basic/JaegerTracerHttpSenderConfiguredSpringTest.java
+++ b/opentracing-spring-cloud-starter-jaeger/src/test/java/io/opentracing/contrib/spring/cloud/starter/jaeger/basic/JaegerTracerHttpSenderConfiguredSpringTest.java
@@ -16,24 +16,24 @@ package io.opentracing.contrib.spring.cloud.starter.jaeger.basic;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.uber.jaeger.reporters.CompositeReporter;
 import io.opentracing.contrib.spring.cloud.starter.jaeger.AbstractSenderSpringTest;
 import org.junit.Test;
 import org.springframework.test.context.TestPropertySource;
 
 @TestPropertySource(
     properties = {
-        "spring.main.banner-mode=off"
+        "spring.main.banner-mode=off",
+        "opentracing.jaeger.httpSender.url=http://test.com"
     }
 )
-public class JaegerTracerServiceNoSenderConfiguredSpringTest extends AbstractSenderSpringTest {
+public class JaegerTracerHttpSenderConfiguredSpringTest extends AbstractSenderSpringTest {
 
   @Test
   public void testExpectedReporter() {
     assertThat(tracer).isNotNull();
     assertThat(tracer).isInstanceOf(com.uber.jaeger.Tracer.class);
 
-    assertSenderClass(com.uber.jaeger.senders.UdpSender.class);
+    assertSenderClass(com.uber.jaeger.senders.HttpSender.class);
   }
 
 }

--- a/opentracing-spring-cloud-starter-jaeger/src/test/java/io/opentracing/contrib/spring/cloud/starter/jaeger/basic/JaegerTracerNoSenderConfiguredSpringTest.java
+++ b/opentracing-spring-cloud-starter-jaeger/src/test/java/io/opentracing/contrib/spring/cloud/starter/jaeger/basic/JaegerTracerNoSenderConfiguredSpringTest.java
@@ -16,24 +16,24 @@ package io.opentracing.contrib.spring.cloud.starter.jaeger.basic;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.uber.jaeger.reporters.CompositeReporter;
 import io.opentracing.contrib.spring.cloud.starter.jaeger.AbstractSenderSpringTest;
 import org.junit.Test;
 import org.springframework.test.context.TestPropertySource;
 
 @TestPropertySource(
     properties = {
-        "spring.main.banner-mode=off",
-        "opentracing.jaeger.httpSender.url=http://test.com"
+        "spring.main.banner-mode=off"
     }
 )
-public class JaegerTracerServiceHttpSenderConfiguredSpringTest extends AbstractSenderSpringTest {
+public class JaegerTracerNoSenderConfiguredSpringTest extends AbstractSenderSpringTest {
 
   @Test
   public void testExpectedReporter() {
     assertThat(tracer).isNotNull();
     assertThat(tracer).isInstanceOf(com.uber.jaeger.Tracer.class);
 
-    assertSenderClass(com.uber.jaeger.senders.HttpSender.class);
+    assertSenderClass(com.uber.jaeger.senders.UdpSender.class);
   }
 
 }


### PR DESCRIPTION
The first commit fixes the flakiness of the Jaeger tests as seen in #122
The second commit simply fixes the names of a couple tests