### PR TITLE
Fixes b3CodecJaegerTracerCustomer not being used when another customizer is present

### DIFF
--- a/opentracing-spring-cloud-starter-jaeger/src/test/java/io/opentracing/contrib/spring/cloud/starter/jaeger/customizer/JaegerTracerB3CustomerizerDisabledSpringTest.java
+++ b/opentracing-spring-cloud-starter-jaeger/src/test/java/io/opentracing/contrib/spring/cloud/starter/jaeger/customizer/JaegerTracerB3CustomerizerDisabledSpringTest.java
@@ -16,6 +16,7 @@ package io.opentracing.contrib.spring.cloud.starter.jaeger.customizer;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import io.opentracing.Tracer;
 import io.opentracing.contrib.spring.cloud.starter.jaeger.AbstractTracerSpringTest;
 import io.opentracing.contrib.spring.cloud.starter.jaeger.TracerBuilderCustomizer;
 import io.opentracing.contrib.spring.cloud.starter.jaeger.customizers.B3CodecTracerBuilderCustomizer;
@@ -34,9 +35,13 @@ public class JaegerTracerB3CustomerizerDisabledSpringTest extends AbstractTracer
 
   @Autowired(required = false)
   private List<TracerBuilderCustomizer> customizers;
+  @Autowired
+  private Tracer tracer;
 
   @Test
   public void testCustomizersShouldContainB3Customizer() {
+    assertThat(tracer).isNotNull();
+
     if (customizers == null) {
       return;
     }


### PR DESCRIPTION
Referencing bean via `@Autowired` in configuration class, which also declares it via `@Bean` is unrealiable - logically, config instance needs to be created in order to call its method, but calling its method populates is field.

Moved customizer list to tracer bean parameter (via ObjectProvider since its optional dependency).
Modified test to verify it works instead of testing contents of customizer collection.

PS: I'm unable to run `JaegerTracerB3CustomerizerEnabledWithEnvVariableSpringTest` with maven, only in IDE. Not sure why. But it uses ugly reflection to inject env variables, which will break in newer JDKs. Since it is testing only Spring Boot property resolution and not the library functionality, and `system-rules` jar is reference only for this test, I suggest to remove this unit test altogether. 