### PR TITLE
Switch to io.jaegertracing

### DIFF
--- a/opentracing-spring-cloud-starter-jaeger/README.md
+++ b/opentracing-spring-cloud-starter-jaeger/README.md
@@ -103,7 +103,7 @@ having to forgo what the auto-configuration provides
   
 The samplers above are mutually exclusive.
 
-A custom sampler could of course be provided by declaring a bean of type `com.uber.jaeger.samplers.Sampler`
+A custom sampler could of course be provided by declaring a bean of type `io.jaegertracing.samplers.Sampler`
 
 ### Propagate headers in B3 format (for compatibility with Zipkin collectors)
 
@@ -116,10 +116,10 @@ A custom sampler could of course be provided by declaring a bean of type `com.ub
 Any of the following beans can be provided by the application (by adding configuring them as bean with `@Bean` for example)
 and will be used to by the Tracer instead of the auto-configured beans.
 
-* `com.uber.jaeger.samplers.Sampler`
-* `com.uber.jaeger.metrics.MetricsFactory`  
+* `io.jaegertracing.samplers.Sampler`
+* `io.jaegertracing.metrics.MetricsFactory`  
 
-### com.uber.jaeger.Tracer.Builder customization
+### io.jaegertracing.Tracer.Builder customization
 
 Right before the `Tracer` is created, it is possible to provide arbitrary customizations to `Tracer.Builder` by providing a bean
 of type `JaegerTracerCustomizer`

--- a/opentracing-spring-cloud-starter-jaeger/pom.xml
+++ b/opentracing-spring-cloud-starter-jaeger/pom.xml
@@ -28,7 +28,7 @@
   <properties>
     <main.basedir>${project.basedir}/..</main.basedir>
 
-    <jaeger.version>0.26.0</jaeger.version>
+    <jaeger.version>0.27.0</jaeger.version>
   </properties>
 
   <dependencies>
@@ -37,7 +37,7 @@
       <artifactId>opentracing-spring-cloud-starter</artifactId>
     </dependency>
     <dependency>
-      <groupId>com.uber.jaeger</groupId>
+      <groupId>io.jaegertracing</groupId>
       <artifactId>jaeger-core</artifactId>
       <version>${jaeger.version}</version>
     </dependency>

--- a/opentracing-spring-cloud-starter-jaeger/src/main/java/io/opentracing/contrib/spring/cloud/starter/jaeger/JaegerConfigurationProperties.java
+++ b/opentracing-spring-cloud-starter-jaeger/src/main/java/io/opentracing/contrib/spring/cloud/starter/jaeger/JaegerConfigurationProperties.java
@@ -13,7 +13,6 @@
  */
 package io.opentracing.contrib.spring.cloud.starter.jaeger;
 
-import com.uber.jaeger.Configuration;
 import org.springframework.boot.context.properties.ConfigurationProperties;
 
 @ConfigurationProperties("opentracing.jaeger")
@@ -223,7 +222,8 @@ public class JaegerConfigurationProperties {
      */
     private String hostPort;
 
-    private Double samplingRate = Configuration.DEFAULT_SAMPLING_PROBABILITY;
+    private Double samplingRate =
+        io.jaegertracing.samplers.ProbabilisticSampler.DEFAULT_SAMPLING_PROBABILITY;
 
 
     public String getHostPort() {

--- a/opentracing-spring-cloud-starter-jaeger/src/main/java/io/opentracing/contrib/spring/cloud/starter/jaeger/ReporterAppender.java
+++ b/opentracing-spring-cloud-starter-jaeger/src/main/java/io/opentracing/contrib/spring/cloud/starter/jaeger/ReporterAppender.java
@@ -13,7 +13,7 @@
  */
 package io.opentracing.contrib.spring.cloud.starter.jaeger;
 
-import com.uber.jaeger.reporters.Reporter;
+import io.jaegertracing.reporters.Reporter;
 import java.util.Collection;
 
 @FunctionalInterface

--- a/opentracing-spring-cloud-starter-jaeger/src/main/java/io/opentracing/contrib/spring/cloud/starter/jaeger/TracerBuilderCustomizer.java
+++ b/opentracing-spring-cloud-starter-jaeger/src/main/java/io/opentracing/contrib/spring/cloud/starter/jaeger/TracerBuilderCustomizer.java
@@ -13,7 +13,7 @@
  */
 package io.opentracing.contrib.spring.cloud.starter.jaeger;
 
-import com.uber.jaeger.Tracer;
+import io.jaegertracing.Tracer;
 
 @FunctionalInterface
 public interface TracerBuilderCustomizer {

--- a/opentracing-spring-cloud-starter-jaeger/src/main/java/io/opentracing/contrib/spring/cloud/starter/jaeger/customizers/B3CodecTracerBuilderCustomizer.java
+++ b/opentracing-spring-cloud-starter-jaeger/src/main/java/io/opentracing/contrib/spring/cloud/starter/jaeger/customizers/B3CodecTracerBuilderCustomizer.java
@@ -13,8 +13,8 @@
  */
 package io.opentracing.contrib.spring.cloud.starter.jaeger.customizers;
 
-import com.uber.jaeger.Tracer;
-import com.uber.jaeger.propagation.B3TextMapCodec;
+import io.jaegertracing.Tracer;
+import io.jaegertracing.propagation.B3TextMapCodec;
 import io.opentracing.contrib.spring.cloud.starter.jaeger.TracerBuilderCustomizer;
 import io.opentracing.propagation.Format;
 

--- a/opentracing-spring-cloud-starter-jaeger/src/test/java/io/opentracing/contrib/spring/cloud/starter/jaeger/AbstractSenderSpringTest.java
+++ b/opentracing-spring-cloud-starter-jaeger/src/test/java/io/opentracing/contrib/spring/cloud/starter/jaeger/AbstractSenderSpringTest.java
@@ -15,8 +15,8 @@ package io.opentracing.contrib.spring.cloud.starter.jaeger;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.uber.jaeger.reporters.CompositeReporter;
-import com.uber.jaeger.reporters.RemoteReporter;
+import io.jaegertracing.reporters.CompositeReporter;
+import io.jaegertracing.reporters.RemoteReporter;
 import org.assertj.core.api.Condition;
 
 public abstract class AbstractSenderSpringTest extends AbstractTracerSpringTest {

--- a/opentracing-spring-cloud-starter-jaeger/src/test/java/io/opentracing/contrib/spring/cloud/starter/jaeger/AbstractTracerSpringTest.java
+++ b/opentracing-spring-cloud-starter-jaeger/src/test/java/io/opentracing/contrib/spring/cloud/starter/jaeger/AbstractTracerSpringTest.java
@@ -30,7 +30,7 @@ public abstract class AbstractTracerSpringTest {
   @Autowired(required = false)
   protected Tracer tracer;
 
-  protected com.uber.jaeger.Tracer getTracer() {
-    return (com.uber.jaeger.Tracer) tracer;
+  protected io.jaegertracing.Tracer getTracer() {
+    return (io.jaegertracing.Tracer) tracer;
   }
 }

--- a/opentracing-spring-cloud-starter-jaeger/src/test/java/io/opentracing/contrib/spring/cloud/starter/jaeger/basic/JaegerTracerExplicitlyEnabledSpringTest.java
+++ b/opentracing-spring-cloud-starter-jaeger/src/test/java/io/opentracing/contrib/spring/cloud/starter/jaeger/basic/JaegerTracerExplicitlyEnabledSpringTest.java
@@ -31,6 +31,6 @@ public class JaegerTracerExplicitlyEnabledSpringTest extends AbstractTracerSprin
   @Test
   public void testIfTracerIsJaegerTracer() {
     assertThat(tracer).isNotNull();
-    assertThat(tracer).isInstanceOf(com.uber.jaeger.Tracer.class);
+    assertThat(tracer).isInstanceOf(io.jaegertracing.Tracer.class);
   }
 }

--- a/opentracing-spring-cloud-starter-jaeger/src/test/java/io/opentracing/contrib/spring/cloud/starter/jaeger/basic/JaegerTracerHttpSenderConfiguredSpringTest.java
+++ b/opentracing-spring-cloud-starter-jaeger/src/test/java/io/opentracing/contrib/spring/cloud/starter/jaeger/basic/JaegerTracerHttpSenderConfiguredSpringTest.java
@@ -31,9 +31,9 @@ public class JaegerTracerHttpSenderConfiguredSpringTest extends AbstractSenderSp
   @Test
   public void testExpectedReporter() {
     assertThat(tracer).isNotNull();
-    assertThat(tracer).isInstanceOf(com.uber.jaeger.Tracer.class);
+    assertThat(tracer).isInstanceOf(io.jaegertracing.Tracer.class);
 
-    assertSenderClass(com.uber.jaeger.senders.HttpSender.class);
+    assertSenderClass(io.jaegertracing.senders.HttpSender.class);
   }
 
 }

--- a/opentracing-spring-cloud-starter-jaeger/src/test/java/io/opentracing/contrib/spring/cloud/starter/jaeger/basic/JaegerTracerImplicitlyEnabledSpringTest.java
+++ b/opentracing-spring-cloud-starter-jaeger/src/test/java/io/opentracing/contrib/spring/cloud/starter/jaeger/basic/JaegerTracerImplicitlyEnabledSpringTest.java
@@ -30,6 +30,6 @@ public class JaegerTracerImplicitlyEnabledSpringTest extends AbstractTracerSprin
   @Test
   public void testIfTracerIsJaegerTracer() {
     assertThat(tracer).isNotNull();
-    assertThat(tracer).isInstanceOf(com.uber.jaeger.Tracer.class);
+    assertThat(tracer).isInstanceOf(io.jaegertracing.Tracer.class);
   }
 }

--- a/opentracing-spring-cloud-starter-jaeger/src/test/java/io/opentracing/contrib/spring/cloud/starter/jaeger/basic/JaegerTracerNoSenderConfiguredSpringTest.java
+++ b/opentracing-spring-cloud-starter-jaeger/src/test/java/io/opentracing/contrib/spring/cloud/starter/jaeger/basic/JaegerTracerNoSenderConfiguredSpringTest.java
@@ -16,7 +16,7 @@ package io.opentracing.contrib.spring.cloud.starter.jaeger.basic;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-import com.uber.jaeger.reporters.CompositeReporter;
+import io.jaegertracing.reporters.CompositeReporter;
 import io.opentracing.contrib.spring.cloud.starter.jaeger.AbstractSenderSpringTest;
 import org.junit.Test;
 import org.springframework.test.context.TestPropertySource;
@@ -31,9 +31,9 @@ public class JaegerTracerNoSenderConfiguredSpringTest extends AbstractSenderSpri
   @Test
   public void testExpectedReporter() {
     assertThat(tracer).isNotNull();
-    assertThat(tracer).isInstanceOf(com.uber.jaeger.Tracer.class);
+    assertThat(tracer).isInstanceOf(io.jaegertracing.Tracer.class);
 
-    assertSenderClass(com.uber.jaeger.senders.UdpSender.class);
+    assertSenderClass(io.jaegertracing.senders.UdpSender.class);
   }
 
 }

--- a/opentracing-spring-cloud-starter-jaeger/src/test/java/io/opentracing/contrib/spring/cloud/starter/jaeger/basic/JaegerTracerServiceNameNotSetSpringTest.java
+++ b/opentracing-spring-cloud-starter-jaeger/src/test/java/io/opentracing/contrib/spring/cloud/starter/jaeger/basic/JaegerTracerServiceNameNotSetSpringTest.java
@@ -31,7 +31,7 @@ public class JaegerTracerServiceNameNotSetSpringTest extends AbstractTracerSprin
   @Test
   public void testNameIsAsExpected() {
     assertThat(tracer).isNotNull();
-    assertThat(tracer).isInstanceOf(com.uber.jaeger.Tracer.class);
+    assertThat(tracer).isInstanceOf(io.jaegertracing.Tracer.class);
 
     assertThat((getTracer()).getServiceName()).isEqualTo("unknown-spring-boot");
   }

--- a/opentracing-spring-cloud-starter-jaeger/src/test/java/io/opentracing/contrib/spring/cloud/starter/jaeger/basic/JaegerTracerServiceNameSetSpringTest.java
+++ b/opentracing-spring-cloud-starter-jaeger/src/test/java/io/opentracing/contrib/spring/cloud/starter/jaeger/basic/JaegerTracerServiceNameSetSpringTest.java
@@ -32,7 +32,7 @@ public class JaegerTracerServiceNameSetSpringTest extends AbstractTracerSpringTe
   @Test
   public void testNameIsAsExpected() {
     assertThat(tracer).isNotNull();
-    assertThat(tracer).isInstanceOf(com.uber.jaeger.Tracer.class);
+    assertThat(tracer).isInstanceOf(io.jaegertracing.Tracer.class);
 
     assertThat((getTracer()).getServiceName()).isEqualTo("foo");
   }

--- a/opentracing-spring-cloud/src/main/java/io/opentracing/contrib/spring/cloud/async/TraceAsyncAspect.java
+++ b/opentracing-spring-cloud/src/main/java/io/opentracing/contrib/spring/cloud/async/TraceAsyncAspect.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 The OpenTracing Authors
+ * Copyright 2017-2018 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -46,13 +46,12 @@ public class TraceAsyncAspect {
     /**
      * We create a span because parent span might be missing. E.g. method is invoked
      */
-    Span span = null;
+    Span span = this.tracer.buildSpan(operationName(pjp))
+        .withTag(Tags.COMPONENT.getKey(), TAG_COMPONENT)
+        .withTag(ExtensionTags.CLASS_TAG.getKey(), pjp.getTarget().getClass().getSimpleName())
+        .withTag(ExtensionTags.METHOD_TAG.getKey(), pjp.getSignature().getName())
+        .start();
     try {
-      span = this.tracer.buildSpan(operationName(pjp))
-          .withTag(Tags.COMPONENT.getKey(), TAG_COMPONENT)
-          .withTag(ExtensionTags.CLASS_TAG.getKey(), pjp.getTarget().getClass().getSimpleName())
-          .withTag(ExtensionTags.METHOD_TAG.getKey(), pjp.getSignature().getName())
-          .startManual();
       return pjp.proceed();
     } catch (Exception ex) {
       SpanUtils.captureException(span, ex);

--- a/opentracing-spring-cloud/src/main/java/io/opentracing/contrib/spring/cloud/zuul/TracePreZuulFilter.java
+++ b/opentracing-spring-cloud/src/main/java/io/opentracing/contrib/spring/cloud/zuul/TracePreZuulFilter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 The OpenTracing Authors
+ * Copyright 2017-2018 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -55,7 +55,7 @@ class TracePreZuulFilter extends ZuulFilter {
     // span is a child of one created in servlet-filter
     Span span = tracer.buildSpan(ctx.getRequest().getMethod())
         .withTag(Tags.COMPONENT.getKey(), COMPONENT_NAME)
-        .startManual();
+        .start();
 
     tracer.inject(span.context(), Format.Builtin.HTTP_HEADERS,
         new TextMapInjectAdapter(ctx.getZuulRequestHeaders()));

--- a/opentracing-spring-cloud/src/test/java/io/opentracing/contrib/spring/cloud/scheduled/ScheduledTest.java
+++ b/opentracing-spring-cloud/src/test/java/io/opentracing/contrib/spring/cloud/scheduled/ScheduledTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 The OpenTracing Authors
+ * Copyright 2017-2018 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -73,7 +73,7 @@ public class ScheduledTest {
       // disable upcoming scheduling
       scheduledAnnotationBeanPostProcessor
           .postProcessBeforeDestruction(beanFactory.getBean(ScheduledComponent.class), null);
-      tracer.buildSpan("child").startManual().finish();
+      tracer.buildSpan("child").start().finish();
     }
   }
 


### PR DESCRIPTION
`com.uber.jaeger` is deprecated in favour of `io.jaegertracing`.
This PR moves to `io.jaegertracing.jaeger-core`, and fixes all the deprecation warnings