### PR TITLE
Add support for authentication in HttpSender

### DIFF
--- a/opentracing-spring-cloud-starter-jaeger/README.md
+++ b/opentracing-spring-cloud-starter-jaeger/README.md
@@ -56,7 +56,17 @@ Configuring senders is as simple as setting a couple necessary properties
 
 ### HTTP Sender
 
-`opentracing.jaeger.http-sender.url = http://jaegerhost:portNumber` 
+`opentracing.jaeger.http-sender.url = http://jaegerhost:portNumber`
+
+It's possible to configure authentication on the HTTP sender by specifying an username and password:
+
+`opentracing.jaeger.http-sender.username = username`
+`opentracing.jaeger.http-sender.password = password`
+
+Or by specifying a bearer token:
+
+`opentracing.jaeger.http-sender.authtoken = token`
+ 
 
 Note that when an HTTP Sender is defined, the UDP sender is not used, even if it has been configured
 

--- a/opentracing-spring-cloud-starter-jaeger/src/main/java/io/opentracing/contrib/spring/cloud/starter/jaeger/JaegerAutoConfiguration.java
+++ b/opentracing-spring-cloud-starter-jaeger/src/main/java/io/opentracing/contrib/spring/cloud/starter/jaeger/JaegerAutoConfiguration.java
@@ -14,7 +14,6 @@
 package io.opentracing.contrib.spring.cloud.starter.jaeger;
 
 import io.jaegertracing.Tracer.Builder;
-import io.jaegertracing.metrics.InMemoryMetricsFactory;
 import io.jaegertracing.metrics.Metrics;
 import io.jaegertracing.metrics.MetricsFactory;
 import io.jaegertracing.metrics.NoopMetricsFactory;
@@ -120,6 +119,12 @@ public class JaegerAutoConfiguration {
     HttpSender.Builder builder = new HttpSender.Builder(httpSenderProperties.getUrl());
     if (httpSenderProperties.getMaxPayload() != null) {
       builder = builder.withMaxPacketSize(httpSenderProperties.getMaxPayload());
+    }
+    if (!StringUtils.isEmpty(httpSenderProperties.getUsername())
+        && !StringUtils.isEmpty(httpSenderProperties.getPassword())) {
+      builder.withAuth(httpSenderProperties.getUsername(), httpSenderProperties.getPassword());
+    } else if (!StringUtils.isEmpty(httpSenderProperties.getAuthToken())) {
+      builder.withAuth(httpSenderProperties.getAuthToken());
     }
 
     return createReporter(metrics, remoteReporter, builder.build());

--- a/opentracing-spring-cloud-starter-jaeger/src/main/java/io/opentracing/contrib/spring/cloud/starter/jaeger/JaegerConfigurationProperties.java
+++ b/opentracing-spring-cloud-starter-jaeger/src/main/java/io/opentracing/contrib/spring/cloud/starter/jaeger/JaegerConfigurationProperties.java
@@ -126,6 +126,12 @@ public class JaegerConfigurationProperties {
 
     private Integer maxPayload = 0;
 
+    private String username;
+
+    private String password;
+
+    private String authToken;
+
     public String getUrl() {
       return url;
     }
@@ -140,6 +146,30 @@ public class JaegerConfigurationProperties {
 
     public void setMaxPayload(Integer maxPayload) {
       this.maxPayload = maxPayload;
+    }
+
+    public String getUsername() {
+      return username;
+    }
+
+    public void setUsername(String username) {
+      this.username = username;
+    }
+
+    public String getPassword() {
+      return password;
+    }
+
+    public void setPassword(String password) {
+      this.password = password;
+    }
+
+    public String getAuthToken() {
+      return authToken;
+    }
+
+    public void setAuthToken(String authToken) {
+      this.authToken = authToken;
     }
   }
 


### PR DESCRIPTION
Support specifying  an username and password or a bearer token in the configuration for the HttpSender used for Trace reporting.