### PR TITLE
Add Mongo tracing

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ It contains auto-configurations for Spring Boot which will instrument and trace 
 * Hystrix
 * JMS
 * JDBC
+* Mongo
 * Zuul
 * RxJava
 * Standard logging - logs are added to active span

--- a/opentracing-spring-cloud-starter/src/test/java/io/opentracing/contrib/spring/cloud/NoDepsTest.java
+++ b/opentracing-spring-cloud-starter/src/test/java/io/opentracing/contrib/spring/cloud/NoDepsTest.java
@@ -55,4 +55,9 @@ public class NoDepsTest {
     this.getClass().getClassLoader().loadClass(
         "org.springframework.web.socket.config.annotation.AbstractWebSocketMessageBrokerConfigurer");
   }
+
+  @Test(expected = ClassNotFoundException.class)
+  public void testNoMongoClient() throws ClassNotFoundException {
+    this.getClass().getClassLoader().loadClass("com.mongodb.MongoClient");
+  }
 }

--- a/opentracing-spring-cloud/pom.xml
+++ b/opentracing-spring-cloud/pom.xml
@@ -76,6 +76,17 @@
     <dependency>
       <groupId>io.opentracing.contrib</groupId>
       <artifactId>opentracing-mongo-driver</artifactId>
+      <exclusions>
+        <exclusion>
+          <artifactId>*</artifactId>
+          <groupId>*</groupId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>org.mongodb</groupId>
+      <artifactId>mongodb-driver</artifactId>
+      <optional>true</optional>
     </dependency>
 
     <dependency>

--- a/opentracing-spring-cloud/pom.xml
+++ b/opentracing-spring-cloud/pom.xml
@@ -74,6 +74,11 @@
     </dependency>
 
     <dependency>
+      <groupId>io.opentracing.contrib</groupId>
+      <artifactId>opentracing-mongo-driver</artifactId>
+    </dependency>
+
+    <dependency>
       <groupId>io.github.openfeign.opentracing</groupId>
       <artifactId>feign-hystrix-opentracing</artifactId>
       <version>${version.io.github.openfeign.opentracing}</version>
@@ -196,6 +201,23 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-data-rest</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-data-mongodb</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>de.flapdoodle.embed</groupId>
+      <artifactId>de.flapdoodle.embed.mongo</artifactId>
+      <version>${version.de.flapdoodle-embed.mongo}</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>cz.jirutka.spring</groupId>
+      <artifactId>embedmongo-spring</artifactId>
+      <version>${version.cz.jirutka.spring-embedmongo-spring}</version>
       <scope>test</scope>
     </dependency>
 

--- a/opentracing-spring-cloud/src/main/java/io/opentracing/contrib/spring/cloud/mongo/MongoTracingAutoConfiguration.java
+++ b/opentracing-spring-cloud/src/main/java/io/opentracing/contrib/spring/cloud/mongo/MongoTracingAutoConfiguration.java
@@ -21,6 +21,7 @@ import java.net.UnknownHostException;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.boot.autoconfigure.mongo.MongoAutoConfiguration;
 import org.springframework.boot.autoconfigure.mongo.MongoProperties;
@@ -32,6 +33,7 @@ import org.springframework.core.env.Environment;
  */
 @Configuration
 @AutoConfigureBefore(MongoAutoConfiguration.class)
+@ConditionalOnClass(MongoClient.class)
 @ConditionalOnBean(Tracer.class)
 @ConditionalOnProperty(name = "opentracing.spring.cloud.mongo.enabled", havingValue = "true", matchIfMissing = true)
 public class MongoTracingAutoConfiguration extends MongoAutoConfiguration {

--- a/opentracing-spring-cloud/src/main/java/io/opentracing/contrib/spring/cloud/mongo/MongoTracingAutoConfiguration.java
+++ b/opentracing-spring-cloud/src/main/java/io/opentracing/contrib/spring/cloud/mongo/MongoTracingAutoConfiguration.java
@@ -19,6 +19,7 @@ import io.opentracing.Tracer;
 import io.opentracing.contrib.mongo.TracingMongoClient;
 import java.net.UnknownHostException;
 import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.autoconfigure.AutoConfigureBefore;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
@@ -40,7 +41,7 @@ public class MongoTracingAutoConfiguration extends MongoAutoConfiguration {
 
   private Tracer tracer;
 
-  public MongoTracingAutoConfiguration(MongoProperties properties,
+  public MongoTracingAutoConfiguration(@Autowired(required = false) MongoProperties properties,
       ObjectProvider<MongoClientOptions> options, Environment environment, Tracer tracer) {
     super(properties, options, environment);
     this.tracer = tracer;

--- a/opentracing-spring-cloud/src/main/java/io/opentracing/contrib/spring/cloud/mongo/MongoTracingAutoConfiguration.java
+++ b/opentracing-spring-cloud/src/main/java/io/opentracing/contrib/spring/cloud/mongo/MongoTracingAutoConfiguration.java
@@ -1,0 +1,52 @@
+/**
+ * Copyright 2017-2018 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.contrib.spring.cloud.mongo;
+
+import com.mongodb.MongoClient;
+import com.mongodb.MongoClientOptions;
+import io.opentracing.Tracer;
+import io.opentracing.contrib.mongo.TracingMongoClient;
+import java.net.UnknownHostException;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.boot.autoconfigure.AutoConfigureBefore;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.mongo.MongoAutoConfiguration;
+import org.springframework.boot.autoconfigure.mongo.MongoProperties;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.env.Environment;
+
+/**
+ * @author Vivien Maleze
+ */
+@Configuration
+@AutoConfigureBefore(MongoAutoConfiguration.class)
+@ConditionalOnBean(Tracer.class)
+@ConditionalOnProperty(name = "opentracing.spring.cloud.mongo.enabled", havingValue = "true", matchIfMissing = true)
+public class MongoTracingAutoConfiguration extends MongoAutoConfiguration {
+
+  private Tracer tracer;
+
+  public MongoTracingAutoConfiguration(MongoProperties properties,
+      ObjectProvider<MongoClientOptions> options, Environment environment, Tracer tracer) {
+    super(properties, options, environment);
+    this.tracer = tracer;
+  }
+
+  @Override
+  public MongoClient mongo() throws UnknownHostException {
+    MongoClient mongo = super.mongo();
+    return new TracingMongoClient(tracer, mongo.getAllAddress(), mongo.getMongoClientOptions());
+  }
+}

--- a/opentracing-spring-cloud/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/opentracing-spring-cloud/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -58,6 +58,12 @@
       "type": "java.lang.Boolean",
       "description": "Add standard logging output to tracing system.",
       "defaultValue": true
+    },
+    {
+      "name": "opentracing.spring.cloud.mongo.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Enable Mongo tracing.",
+      "defaultValue": true
     }
   ]
 }

--- a/opentracing-spring-cloud/src/main/resources/META-INF/spring.factories
+++ b/opentracing-spring-cloud/src/main/resources/META-INF/spring.factories
@@ -9,7 +9,8 @@ io.opentracing.contrib.spring.cloud.hystrix.HystrixTracingAutoConfiguration,\
 io.opentracing.contrib.spring.cloud.websocket.WebsocketAutoConfiguration,\
 io.opentracing.contrib.spring.cloud.scheduled.ScheduledAutoConfiguration,\
 io.opentracing.contrib.spring.cloud.log.LoggingAutoConfiguration,\
-io.opentracing.contrib.spring.cloud.rxjava.RxJavaTracingAutoConfiguration
+io.opentracing.contrib.spring.cloud.rxjava.RxJavaTracingAutoConfiguration,\
+io.opentracing.contrib.spring.cloud.mongo.MongoTracingAutoConfiguration
 
 # Environment Post Processor
 org.springframework.boot.env.EnvironmentPostProcessor=\

--- a/opentracing-spring-cloud/src/test/java/io/opentracing/contrib/spring/cloud/mongo/MongoTracingAutoConfigurationTest.java
+++ b/opentracing-spring-cloud/src/test/java/io/opentracing/contrib/spring/cloud/mongo/MongoTracingAutoConfigurationTest.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2017-2018 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package io.opentracing.contrib.spring.cloud.mongo;
 
 import static org.hamcrest.Matchers.is;
@@ -14,35 +27,35 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 /**
- * @author  Vivien Maleze
+ * @author Vivien Maleze
  */
 public class MongoTracingAutoConfigurationTest {
 
-    @Test
-    public void loadMongoTracingByDefault() {
-        AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
-        context.register(TracerConfig.class, MongoTracingAutoConfiguration.class);
-        context.refresh();
-        MongoClient mongoClient = context.getBean(MongoClient.class);
-        assertNotNull(mongoClient);
-    }
+  @Test
+  public void loadMongoTracingByDefault() {
+    AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
+    context.register(TracerConfig.class, MongoTracingAutoConfiguration.class);
+    context.refresh();
+    MongoClient mongoClient = context.getBean(MongoClient.class);
+    assertNotNull(mongoClient);
+  }
 
-    @Test
-    public void disableMongoTracing() {
-        AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
-        context.register(TracerConfig.class, MongoTracingAutoConfiguration.class);
-        EnvironmentTestUtils.addEnvironment(context, "opentracing.spring.cloud.mongo.enabled:false");
-        context.refresh();
-        String[] tracingMongoClientBeans = context.getBeanNamesForType(MongoClient.class);
-        assertThat(tracingMongoClientBeans.length, is(0));
-    }
+  @Test
+  public void disableMongoTracing() {
+    AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
+    context.register(TracerConfig.class, MongoTracingAutoConfiguration.class);
+    EnvironmentTestUtils.addEnvironment(context, "opentracing.spring.cloud.mongo.enabled:false");
+    context.refresh();
+    String[] tracingMongoClientBeans = context.getBeanNamesForType(MongoClient.class);
+    assertThat(tracingMongoClientBeans.length, is(0));
+  }
 
-    @Configuration
-    static class TracerConfig {
+  @Configuration
+  static class TracerConfig {
 
-        @Bean
-        public Tracer tracer() {
-            return mock(Tracer.class);
-        }
+    @Bean
+    public Tracer tracer() {
+      return mock(Tracer.class);
     }
+  }
 }

--- a/opentracing-spring-cloud/src/test/java/io/opentracing/contrib/spring/cloud/mongo/MongoTracingAutoConfigurationTest.java
+++ b/opentracing-spring-cloud/src/test/java/io/opentracing/contrib/spring/cloud/mongo/MongoTracingAutoConfigurationTest.java
@@ -1,0 +1,48 @@
+package io.opentracing.contrib.spring.cloud.mongo;
+
+import static org.hamcrest.Matchers.is;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThat;
+import static org.mockito.Mockito.mock;
+
+import com.mongodb.MongoClient;
+import io.opentracing.Tracer;
+import org.junit.Test;
+import org.springframework.boot.test.util.EnvironmentTestUtils;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+/**
+ * @author  Vivien Maleze
+ */
+public class MongoTracingAutoConfigurationTest {
+
+    @Test
+    public void loadMongoTracingByDefault() {
+        AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
+        context.register(TracerConfig.class, MongoTracingAutoConfiguration.class);
+        context.refresh();
+        MongoClient mongoClient = context.getBean(MongoClient.class);
+        assertNotNull(mongoClient);
+    }
+
+    @Test
+    public void disableMongoTracing() {
+        AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
+        context.register(TracerConfig.class, MongoTracingAutoConfiguration.class);
+        EnvironmentTestUtils.addEnvironment(context, "opentracing.spring.cloud.mongo.enabled:false");
+        context.refresh();
+        String[] tracingMongoClientBeans = context.getBeanNamesForType(MongoClient.class);
+        assertThat(tracingMongoClientBeans.length, is(0));
+    }
+
+    @Configuration
+    static class TracerConfig {
+
+        @Bean
+        public Tracer tracer() {
+            return mock(Tracer.class);
+        }
+    }
+}

--- a/opentracing-spring-cloud/src/test/java/io/opentracing/contrib/spring/cloud/mongo/MongoTracingTest.java
+++ b/opentracing-spring-cloud/src/test/java/io/opentracing/contrib/spring/cloud/mongo/MongoTracingTest.java
@@ -1,0 +1,142 @@
+/**
+ * Copyright 2017-2018 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.contrib.spring.cloud.mongo;
+
+import static org.awaitility.Awaitility.await;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import com.mongodb.MongoClient;
+import io.opentracing.Scope;
+import io.opentracing.contrib.mongo.TracingMongoClient;
+import io.opentracing.contrib.spring.cloud.MockTracingConfiguration;
+import io.opentracing.mock.MockSpan;
+import io.opentracing.mock.MockTracer;
+import io.opentracing.tag.Tags;
+import java.util.List;
+import java.util.Optional;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.data.mongodb.core.MongoTemplate;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+/**
+ * @author Vivien Maleze
+ */
+@SpringBootTest(
+    webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
+    classes = {MockTracingConfiguration.class})
+@RunWith(SpringJUnit4ClassRunner.class)
+public class MongoTracingTest {
+
+  @Autowired
+  MockTracer tracer;
+
+  @Autowired
+  MongoClient mongoClient;
+
+  @Autowired
+  MongoTemplate mongoTemplate;
+
+  @Before
+  public void before() {
+    tracer.reset();
+  }
+
+  /**
+   * Make sure we get a TracingMongoClient instead of a normal MongoClient
+   */
+  @Test
+  public void mongoTracerIsInstrumented() {
+    assertTrue(mongoClient instanceof TracingMongoClient);
+  }
+
+  /**
+   * Make sure we get one span once we execute a database call.
+   */
+  @Test
+  public void spanIsCreatedForCommandExecution() {
+    this.mongoTemplate.executeCommand("{ buildInfo: 1 }");
+    assertEquals(1, tracer.finishedSpans().size());
+  }
+
+  /**
+   * Make sure that a span is created when an active span exists joins the active
+   */
+  @Test
+  public void spanJoinsActiveSpan() {
+    try (Scope ignored = tracer.buildSpan("parent").startActive(true)) {
+      assertTrue(this.mongoTemplate.executeCommand("{ buildInfo: 1 }").ok());
+      assertEquals(1, tracer.finishedSpans().size());
+    }
+
+    assertEquals(2, tracer.finishedSpans().size());
+    Optional<MockSpan> mongoSpan = tracer
+        .finishedSpans()
+        .stream()
+        .filter(s -> "java-mongo".equals(s.tags().get(Tags.COMPONENT.getKey())))
+        .findFirst();
+
+    Optional<MockSpan> parentSpan = tracer
+        .finishedSpans()
+        .stream()
+        .filter(s -> "parent".equals(s.operationName()))
+        .findFirst();
+
+    assertTrue(mongoSpan.isPresent());
+    assertTrue(parentSpan.isPresent());
+
+    assertEquals(mongoSpan.get().context().traceId(), parentSpan.get().context().traceId());
+    assertEquals(mongoSpan.get().parentId(), parentSpan.get().context().spanId());
+  }
+
+
+  /**
+   * Sanity test for multiple requests, on their own threads, each executing a mongo command
+   */
+  @Test
+  public void concurrentParents() {
+    ExecutorService service = Executors.newFixedThreadPool(10);
+    IntStream.rangeClosed(1, 150).parallel().forEach(i -> service.submit(() -> {
+      // each iteration is like a request
+      try (Scope parent = tracer.buildSpan("parent_" + i).startActive(true)) {
+        parent.span().setTag("iteration", i);
+        this.mongoTemplate.executeCommand("{ buildInfo : " + i + " }");
+      }
+    }));
+
+    // for each request, we have one extra span, the jdbc one
+    await().until(() -> tracer.finishedSpans().size() == 300);
+
+    tracer.finishedSpans()
+        .stream()
+        .filter(s -> s.operationName().startsWith("parent_"))
+        .forEach(parent -> {
+          List<MockSpan> child = tracer.finishedSpans()
+              .stream()
+              .filter(c -> c.parentId() == parent.context().spanId())
+              .collect(Collectors.toList());
+          assertEquals(1, child.size());
+          assertEquals("{ \"buildInfo\" : " + parent.tags().get("iteration") + " }",
+              child.get(0).tags().get("db.statement"));
+        });
+  }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -71,6 +71,7 @@
     <version.io.opentracing.contrib-java-jdbc>0.0.6</version.io.opentracing.contrib-java-jdbc>
     <version.io.opentracing.contrib-java-concurrent>0.1.0</version.io.opentracing.contrib-java-concurrent>
     <version.io.opentracing.contrib-opentracing-rxjava-1>0.0.7</version.io.opentracing.contrib-opentracing-rxjava-1>
+    <version.io.opentracing.contrib-opentracing-spring-mongo>0.0.4</version.io.opentracing.contrib-opentracing-spring-mongo>
     <version.io.github.openfeign-feign-okhttp>9.5.0</version.io.github.openfeign-feign-okhttp>
     <version.io.github.openfeign.opentracing>0.1.0</version.io.github.openfeign.opentracing>
     <!-- spring-boot-starter-parent is a module of spring-boot-dependencies
@@ -78,6 +79,8 @@
     <version.org.springframework.boot>1.5.12.RELEASE</version.org.springframework.boot>
     <version.org.springframework.cloud-spring-cloud-dependencies>Edgware.SR3</version.org.springframework.cloud-spring-cloud-dependencies>
     <version.org.awaitility-awaitility>3.0.0</version.org.awaitility-awaitility>
+    <version.de.flapdoodle-embed.mongo>2.0.3</version.de.flapdoodle-embed.mongo>
+    <version.cz.jirutka.spring-embedmongo-spring>1.3.1</version.cz.jirutka.spring-embedmongo-spring>
 
     <version.javax.jms>1.1-rev-1</version.javax.jms>
 
@@ -165,6 +168,12 @@
         <groupId>io.opentracing.contrib</groupId>
         <artifactId>opentracing-spring-messaging-starter</artifactId>
         <version>${version.io.opentracing.contrib-opentracing-spring-messaging}</version>
+      </dependency>
+
+      <dependency>
+        <groupId>io.opentracing.contrib</groupId>
+        <artifactId>opentracing-mongo-driver</artifactId>
+        <version>${version.io.opentracing.contrib-opentracing-spring-mongo}</version>
       </dependency>
 
       <dependency>


### PR DESCRIPTION
Resolves #127 

Simple auto configuration overriding the `MongoClient` and creating a `TracingMongoClient` by using the `opentracing-mongo-driver`