### PR TITLE
Make JDBC tracer configurable through Spring properties

### DIFF
--- a/opentracing-spring-cloud/src/main/java/io/opentracing/contrib/spring/cloud/jdbc/JdbcAutoConfiguration.java
+++ b/opentracing-spring-cloud/src/main/java/io/opentracing/contrib/spring/cloud/jdbc/JdbcAutoConfiguration.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017 The OpenTracing Authors
+ * Copyright 2017-2018 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/opentracing-spring-cloud/src/main/java/io/opentracing/contrib/spring/cloud/jdbc/JdbcAutoConfiguration.java
+++ b/opentracing-spring-cloud/src/main/java/io/opentracing/contrib/spring/cloud/jdbc/JdbcAutoConfiguration.java
@@ -13,7 +13,10 @@
  */
 package io.opentracing.contrib.spring.cloud.jdbc;
 
+import java.util.HashSet;
+import java.util.Set;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.ConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -24,10 +27,30 @@ import org.springframework.context.annotation.Configuration;
  */
 @Configuration
 @ConditionalOnProperty(name = "opentracing.spring.cloud.jdbc.enabled", havingValue = "true", matchIfMissing = true)
+@ConfigurationProperties(prefix = "opentracing.spring.cloud.jdbc")
 public class JdbcAutoConfiguration {
+
+  private boolean withActiveSpanOnly = false;
+  private Set<String> ignoreStatements = new HashSet<>();
+
+  public boolean isWithActiveSpanOnly() {
+    return withActiveSpanOnly;
+  }
+
+  public void setWithActiveSpanOnly(boolean withActiveSpanOnly) {
+    this.withActiveSpanOnly = withActiveSpanOnly;
+  }
+
+  public Set<String> getIgnoreStatements() {
+    return ignoreStatements;
+  }
+
+  public void setIgnoreStatements(Set<String> ignoreStatements) {
+    this.ignoreStatements = ignoreStatements;
+  }
 
   @Bean
   public JdbcAspect jdbcAspect() {
-    return new JdbcAspect();
+    return new JdbcAspect(withActiveSpanOnly, ignoreStatements);
   }
 }

--- a/opentracing-spring-cloud/src/test/java/io/opentracing/contrib/spring/cloud/jdbc/JdbcIgnoredStatements.java
+++ b/opentracing-spring-cloud/src/test/java/io/opentracing/contrib/spring/cloud/jdbc/JdbcIgnoredStatements.java
@@ -1,3 +1,17 @@
+/**
+ * Copyright 2017-2018 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
 package io.opentracing.contrib.spring.cloud.jdbc;
 
 import static org.junit.Assert.assertEquals;
@@ -28,37 +42,37 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 })
 public class JdbcIgnoredStatements {
 
-    @Autowired
-    MockTracer tracer;
+  @Autowired
+  MockTracer tracer;
 
-    @Autowired
-    DataSource dataSource;
+  @Autowired
+  DataSource dataSource;
 
-    @Autowired
-    JdbcTemplate jdbcTemplate;
+  @Autowired
+  JdbcTemplate jdbcTemplate;
 
-    @Before
-    public void before() {
-        tracer.reset();
-    }
+  @Before
+  public void before() {
+    tracer.reset();
+  }
 
-    /**
-     * Make sure ignored statements aren't traced
-     */
-    @Test
-    public void spanIsNotCreatedForIgnoredStatement() throws SQLException {
-        PreparedStatement pstmt = dataSource.getConnection().prepareStatement("SELECT 1");
-        assertTrue(pstmt.execute());
-        assertEquals(0, tracer.finishedSpans().size());
-    }
+  /**
+   * Make sure ignored statements aren't traced
+   */
+  @Test
+  public void spanIsNotCreatedForIgnoredStatement() throws SQLException {
+    PreparedStatement pstmt = dataSource.getConnection().prepareStatement("SELECT 1");
+    assertTrue(pstmt.execute());
+    assertEquals(0, tracer.finishedSpans().size());
+  }
 
-    /**
-     * Make sure statements that aren't ignored aren't affected
-     */
-    @Test
-    public void spanIsCreatedNonIgnoredStatement() throws SQLException {
-        PreparedStatement pstmt = dataSource.getConnection().prepareStatement("SELECT 2");
-        assertTrue(pstmt.execute());
-        assertEquals(1, tracer.finishedSpans().size());
-    }
+  /**
+   * Make sure statements that aren't ignored aren't affected
+   */
+  @Test
+  public void spanIsCreatedNonIgnoredStatement() throws SQLException {
+    PreparedStatement pstmt = dataSource.getConnection().prepareStatement("SELECT 2");
+    assertTrue(pstmt.execute());
+    assertEquals(1, tracer.finishedSpans().size());
+  }
 }

--- a/opentracing-spring-cloud/src/test/java/io/opentracing/contrib/spring/cloud/jdbc/JdbcIgnoredStatements.java
+++ b/opentracing-spring-cloud/src/test/java/io/opentracing/contrib/spring/cloud/jdbc/JdbcIgnoredStatements.java
@@ -1,0 +1,64 @@
+package io.opentracing.contrib.spring.cloud.jdbc;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import io.opentracing.contrib.spring.cloud.MockTracingConfiguration;
+import io.opentracing.mock.MockTracer;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import javax.sql.DataSource;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+/**
+ * Test behaviour when ignored statements are configured
+ * @author Will Penington
+ */
+@SpringBootTest(classes = {MockTracingConfiguration.class})
+@RunWith(SpringJUnit4ClassRunner.class)
+@TestPropertySource(properties = {
+        "opentracing.spring.cloud.jdbc.ignoreStatements=SELECT 1"
+})
+public class JdbcIgnoredStatements {
+
+    @Autowired
+    MockTracer tracer;
+
+    @Autowired
+    DataSource dataSource;
+
+    @Autowired
+    JdbcTemplate jdbcTemplate;
+
+    @Before
+    public void before() {
+        tracer.reset();
+    }
+
+    /**
+     * Make sure ignored statements aren't traced
+     */
+    @Test
+    public void spanIsNotCreatedForIgnoredStatement() throws SQLException {
+        PreparedStatement pstmt = dataSource.getConnection().prepareStatement("SELECT 1");
+        assertTrue(pstmt.execute());
+        assertEquals(0, tracer.finishedSpans().size());
+    }
+
+    /**
+     * Make sure statements that aren't ignored aren't affected
+     */
+    @Test
+    public void spanIsCreatedNonIgnoredStatement() throws SQLException {
+        PreparedStatement pstmt = dataSource.getConnection().prepareStatement("SELECT 2");
+        assertTrue(pstmt.execute());
+        assertEquals(1, tracer.finishedSpans().size());
+    }
+}

--- a/opentracing-spring-cloud/src/test/java/io/opentracing/contrib/spring/cloud/jdbc/JdbcOnlyWithActiveTest.java
+++ b/opentracing-spring-cloud/src/test/java/io/opentracing/contrib/spring/cloud/jdbc/JdbcOnlyWithActiveTest.java
@@ -1,0 +1,83 @@
+package io.opentracing.contrib.spring.cloud.jdbc;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import io.opentracing.Scope;
+import io.opentracing.contrib.spring.cloud.MockTracingConfiguration;
+import io.opentracing.mock.MockSpan;
+import io.opentracing.mock.MockTracer;
+import io.opentracing.tag.Tags;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.Optional;
+import javax.sql.DataSource;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+/**
+ * Test behaviour when withActiveSpanOnly is set
+ * @author Will Penington
+ */
+@SpringBootTest(classes = {MockTracingConfiguration.class})
+@RunWith(SpringJUnit4ClassRunner.class)
+@TestPropertySource(properties = {
+        "opentracing.spring.cloud.jdbc.withActiveSpanOnly=true"
+})
+public class JdbcOnlyWithActiveTest {
+
+    @Autowired
+    MockTracer tracer;
+
+    @Autowired
+    DataSource dataSource;
+
+    @Autowired
+    JdbcTemplate jdbcTemplate;
+
+    @Autowired
+    JdbcAutoConfiguration jdbcAutoConfiguration;
+
+    @Before
+    public void before() {
+        tracer.reset();
+    }
+
+    /**
+     * Make sure that a span is created when an active span exists.
+     */
+    @Test
+    public void spanJoinsActiveSpan() throws SQLException {
+        try (Scope ignored = tracer.buildSpan("parent").startActive(true)) {
+            assertTrue(dataSource.getConnection().prepareStatement("select 1").execute());
+            assertEquals(1, tracer.finishedSpans().size());
+        }
+
+        assertEquals(2, tracer.finishedSpans().size());
+
+        Optional<MockSpan> jdbcSpan = tracer
+                .finishedSpans()
+                .stream()
+                .filter((s) -> "java-jdbc".equals(s.tags().get(Tags.COMPONENT.getKey())))
+                .findFirst();
+
+        assertTrue(jdbcSpan.isPresent());
+    }
+
+    /**
+     * Make sure a new span is not created when there is no active parent span.
+     */
+    @Test
+    public void spanIsCreatedForPreparedStatement() throws SQLException {
+        PreparedStatement pstmt = dataSource.getConnection().prepareStatement("select 1");
+        assertTrue(pstmt.execute());
+        assertEquals(0, tracer.finishedSpans().size());
+    }
+
+}

--- a/opentracing-spring-cloud/src/test/java/io/opentracing/contrib/spring/cloud/jdbc/JdbcOnlyWithActiveTest.java
+++ b/opentracing-spring-cloud/src/test/java/io/opentracing/contrib/spring/cloud/jdbc/JdbcOnlyWithActiveTest.java
@@ -1,3 +1,17 @@
+/**
+ * Copyright 2017-2018 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
 package io.opentracing.contrib.spring.cloud.jdbc;
 
 import static org.junit.Assert.assertEquals;
@@ -32,52 +46,49 @@ import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
 })
 public class JdbcOnlyWithActiveTest {
 
-    @Autowired
-    MockTracer tracer;
+  @Autowired
+  MockTracer tracer;
 
-    @Autowired
-    DataSource dataSource;
+  @Autowired
+  DataSource dataSource;
 
-    @Autowired
-    JdbcTemplate jdbcTemplate;
+  @Autowired
+  JdbcTemplate jdbcTemplate;
 
-    @Autowired
-    JdbcAutoConfiguration jdbcAutoConfiguration;
+  @Before
+  public void before() {
+    tracer.reset();
+  }
 
-    @Before
-    public void before() {
-        tracer.reset();
+  /**
+   * Make sure that a span is created when an active span exists.
+   */
+  @Test
+  public void spanJoinsActiveSpan() throws SQLException {
+    try (Scope ignored = tracer.buildSpan("parent").startActive(true)) {
+      assertTrue(dataSource.getConnection().prepareStatement("select 1").execute());
+      assertEquals(1, tracer.finishedSpans().size());
     }
 
-    /**
-     * Make sure that a span is created when an active span exists.
-     */
-    @Test
-    public void spanJoinsActiveSpan() throws SQLException {
-        try (Scope ignored = tracer.buildSpan("parent").startActive(true)) {
-            assertTrue(dataSource.getConnection().prepareStatement("select 1").execute());
-            assertEquals(1, tracer.finishedSpans().size());
-        }
+    assertEquals(2, tracer.finishedSpans().size());
 
-        assertEquals(2, tracer.finishedSpans().size());
+    Optional<MockSpan> jdbcSpan = tracer
+            .finishedSpans()
+            .stream()
+            .filter((s) -> "java-jdbc".equals(s.tags().get(Tags.COMPONENT.getKey())))
+            .findFirst();
 
-        Optional<MockSpan> jdbcSpan = tracer
-                .finishedSpans()
-                .stream()
-                .filter((s) -> "java-jdbc".equals(s.tags().get(Tags.COMPONENT.getKey())))
-                .findFirst();
+    assertTrue(jdbcSpan.isPresent());
+  }
 
-        assertTrue(jdbcSpan.isPresent());
-    }
-
-    /**
-     * Make sure a new span is not created when there is no active parent span.
-     */
-    @Test
-    public void spanIsCreatedForPreparedStatement() throws SQLException {
-        PreparedStatement pstmt = dataSource.getConnection().prepareStatement("select 1");
-        assertTrue(pstmt.execute());
-        assertEquals(0, tracer.finishedSpans().size());
-    }
+  /**
+   * Make sure a new span is not created when there is no active parent span.
+   */
+  @Test
+  public void spanIsCreatedForPreparedStatement() throws SQLException {
+    PreparedStatement pstmt = dataSource.getConnection().prepareStatement("select 1");
+    assertTrue(pstmt.execute());
+    assertEquals(0, tracer.finishedSpans().size());
+  }
 
 }

--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,7 @@
     <version.io.opentracing.contrib-opentracing-spring-web>0.2.1</version.io.opentracing.contrib-opentracing-spring-web>
     <version.io.opentracing.contrib-opentracing-spring-jms>0.0.5</version.io.opentracing.contrib-opentracing-spring-jms>
     <version.io.opentracing.contrib-opentracing-spring-messaging>0.0.5</version.io.opentracing.contrib-opentracing-spring-messaging>
-    <version.io.opentracing.contrib-java-jdbc>0.0.6</version.io.opentracing.contrib-java-jdbc>
+    <version.io.opentracing.contrib-java-jdbc>0.0.7</version.io.opentracing.contrib-java-jdbc>
     <version.io.opentracing.contrib-java-concurrent>0.1.0</version.io.opentracing.contrib-java-concurrent>
     <version.io.opentracing.contrib-opentracing-rxjava-1>0.0.7</version.io.opentracing.contrib-opentracing-rxjava-1>
     <version.io.github.openfeign-feign-okhttp>9.5.0</version.io.github.openfeign-feign-okhttp>


### PR DESCRIPTION
Add properties for "withActiveSpanOnly" and "ignoreStatement" so
the behaviour of the JDBC tracer can be controlled through
application.yaml