### PR TITLE
Backport Redis instrumentation to SB-1.x

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -33,3 +33,6 @@ hs_err_pid*
 # Intellij Idea
 *.iml
 .idea/
+
+# VS Code
+.vscode/

--- a/README.md
+++ b/README.md
@@ -15,6 +15,7 @@ It contains auto-configurations which instruments and trace following Spring Boo
 * Mongo
 * Zuul
 * RxJava
+* Redis
 * Standard logging - logs are added to active span
 * Spring Messaging - trace messages being sent through [Messaging Channels](https://docs.spring.io/spring-integration/reference/html/messaging-channels-section.html)
 * RabbitMQ

--- a/instrument-starters/opentracing-spring-cloud-jdbc-starter/src/main/java/io/opentracing/contrib/spring/cloud/jdbc/JdbcAutoConfiguration.java
+++ b/instrument-starters/opentracing-spring-cloud-jdbc-starter/src/main/java/io/opentracing/contrib/spring/cloud/jdbc/JdbcAutoConfiguration.java
@@ -16,6 +16,7 @@ package io.opentracing.contrib.spring.cloud.jdbc;
 import io.opentracing.contrib.spring.tracer.configuration.TracerRegisterAutoConfiguration;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -27,10 +28,12 @@ import org.springframework.context.annotation.Configuration;
 @Configuration
 @AutoConfigureAfter(TracerRegisterAutoConfiguration.class)
 @ConditionalOnProperty(name = "opentracing.spring.cloud.jdbc.enabled", havingValue = "true", matchIfMissing = true)
+@EnableConfigurationProperties(JdbcTracingProperties.class)
 public class JdbcAutoConfiguration {
 
   @Bean
-  public JdbcAspect jdbcAspect() {
-    return new JdbcAspect();
+  public JdbcAspect jdbcAspect(JdbcTracingProperties jdbcTracingProperties) {
+    return new JdbcAspect(jdbcTracingProperties.isWithActiveSpanOnly(),
+        jdbcTracingProperties.getIgnoreStatements());
   }
 }

--- a/instrument-starters/opentracing-spring-cloud-jdbc-starter/src/main/java/io/opentracing/contrib/spring/cloud/jdbc/JdbcTracingProperties.java
+++ b/instrument-starters/opentracing-spring-cloud-jdbc-starter/src/main/java/io/opentracing/contrib/spring/cloud/jdbc/JdbcTracingProperties.java
@@ -1,0 +1,48 @@
+/**
+ * Copyright 2017-2018 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.contrib.spring.cloud.jdbc;
+
+import java.util.HashSet;
+import java.util.Set;
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties(prefix = "opentracing.spring.cloud.jdbc")
+public class JdbcTracingProperties {
+
+  /**
+   * Trace JDBC calls only if it's part of an active span.
+   */
+  private boolean withActiveSpanOnly = false;
+  /**
+   * Set of JDBC statement calls to not trace.
+   */
+  private Set<String> ignoreStatements = new HashSet<>();
+
+  public boolean isWithActiveSpanOnly() {
+    return withActiveSpanOnly;
+  }
+
+  public void setWithActiveSpanOnly(boolean withActiveSpanOnly) {
+    this.withActiveSpanOnly = withActiveSpanOnly;
+  }
+
+  public Set<String> getIgnoreStatements() {
+    return ignoreStatements;
+  }
+
+  public void setIgnoreStatements(Set<String> ignoreStatements) {
+    this.ignoreStatements = ignoreStatements;
+  }
+
+}

--- a/instrument-starters/opentracing-spring-cloud-jdbc-starter/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/instrument-starters/opentracing-spring-cloud-jdbc-starter/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -5,6 +5,18 @@
       "type": "java.lang.Boolean",
       "description": "Enable JDBC tracing.",
       "defaultValue": true
+    },
+    {
+      "name": "opentracing.spring.cloud.jdbc.withActiveSpanOnly",
+      "type": "java.lang.Boolean",
+      "description": "Only trace JDBC calls if they are part of an active Span.",
+      "defaultValue": false
+    },
+    {
+      "name": "opentracing.spring.cloud.jdbc.ignoreStatements",
+      "type": "java.util.Set<java.lang.String>",
+      "description": "Set of JDBC statements to not trace.",
+      "defaultValue": null
     }
   ]
 }

--- a/instrument-starters/opentracing-spring-cloud-jdbc-starter/src/test/java/io/opentracing/contrib/spring/cloud/jdbc/JdbcTracingTest.java
+++ b/instrument-starters/opentracing-spring-cloud-jdbc-starter/src/test/java/io/opentracing/contrib/spring/cloud/jdbc/JdbcTracingTest.java
@@ -11,7 +11,7 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package io.opemtracing.contrib.spring.cloud.jdbc;
+package io.opentracing.contrib.spring.cloud.jdbc;
 
 import static org.awaitility.Awaitility.await;
 import static org.junit.Assert.assertEquals;

--- a/instrument-starters/opentracing-spring-cloud-jdbc-starter/src/test/java/io/opentracing/contrib/spring/cloud/jdbc/MockTracingConfiguration.java
+++ b/instrument-starters/opentracing-spring-cloud-jdbc-starter/src/test/java/io/opentracing/contrib/spring/cloud/jdbc/MockTracingConfiguration.java
@@ -11,25 +11,24 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package io.opemtracing.contrib.spring.cloud.jdbc.data;
+package io.opentracing.contrib.spring.cloud.jdbc;
 
-import javax.persistence.Entity;
-import javax.persistence.GeneratedValue;
-import javax.persistence.GenerationType;
-import javax.persistence.Id;
+import io.opentracing.mock.MockTracer;
+import io.opentracing.util.GlobalTracerTestUtil;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
 
-@Entity
-public class TestEntity {
+/**
+ * @author Pavol Loffay
+ */
+@Configuration
+@EnableAutoConfiguration
+public class MockTracingConfiguration {
 
-  @Id
-  @GeneratedValue(strategy = GenerationType.AUTO)
-  private Long id;
-
-  public Long getId() {
-    return id;
-  }
-
-  public void setId(Long id) {
-    this.id = id;
+  @Bean
+  public MockTracer mockTracer() {
+    GlobalTracerTestUtil.resetGlobalTracer();
+    return new MockTracer();
   }
 }

--- a/instrument-starters/opentracing-spring-cloud-jdbc-starter/src/test/java/io/opentracing/contrib/spring/cloud/jdbc/data/SpringDataTracingTest.java
+++ b/instrument-starters/opentracing-spring-cloud-jdbc-starter/src/test/java/io/opentracing/contrib/spring/cloud/jdbc/data/SpringDataTracingTest.java
@@ -11,12 +11,12 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package io.opemtracing.contrib.spring.cloud.jdbc.data;
+package io.opentracing.contrib.spring.cloud.jdbc.data;
 
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 
-import io.opemtracing.contrib.spring.cloud.jdbc.MockTracingConfiguration;
+import io.opentracing.contrib.spring.cloud.jdbc.MockTracingConfiguration;
 import io.opentracing.mock.MockSpan;
 import io.opentracing.mock.MockTracer;
 import io.opentracing.tag.Tags;

--- a/instrument-starters/opentracing-spring-cloud-jdbc-starter/src/test/java/io/opentracing/contrib/spring/cloud/jdbc/data/TestEntity.java
+++ b/instrument-starters/opentracing-spring-cloud-jdbc-starter/src/test/java/io/opentracing/contrib/spring/cloud/jdbc/data/TestEntity.java
@@ -11,24 +11,25 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package io.opemtracing.contrib.spring.cloud.jdbc;
+package io.opentracing.contrib.spring.cloud.jdbc.data;
 
-import io.opentracing.mock.MockTracer;
-import io.opentracing.util.GlobalTracerTestUtil;
-import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
-import org.springframework.context.annotation.Bean;
-import org.springframework.context.annotation.Configuration;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
 
-/**
- * @author Pavol Loffay
- */
-@Configuration
-@EnableAutoConfiguration
-public class MockTracingConfiguration {
+@Entity
+public class TestEntity {
 
-  @Bean
-  public MockTracer mockTracer() {
-    GlobalTracerTestUtil.resetGlobalTracer();
-    return new MockTracer();
+  @Id
+  @GeneratedValue(strategy = GenerationType.AUTO)
+  private Long id;
+
+  public Long getId() {
+    return id;
+  }
+
+  public void setId(Long id) {
+    this.id = id;
   }
 }

--- a/instrument-starters/opentracing-spring-cloud-jdbc-starter/src/test/java/io/opentracing/contrib/spring/cloud/jdbc/data/TestEntityRepository.java
+++ b/instrument-starters/opentracing-spring-cloud-jdbc-starter/src/test/java/io/opentracing/contrib/spring/cloud/jdbc/data/TestEntityRepository.java
@@ -11,7 +11,7 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package io.opemtracing.contrib.spring.cloud.jdbc.data;
+package io.opentracing.contrib.spring.cloud.jdbc.data;
 
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.data.rest.core.annotation.RepositoryRestResource;

--- a/instrument-starters/opentracing-spring-cloud-jdbc-starter/src/test/java/io/opentracing/contrib/spring/cloud/jdbc/jdbc/JdbcIgnoredStatements.java
+++ b/instrument-starters/opentracing-spring-cloud-jdbc-starter/src/test/java/io/opentracing/contrib/spring/cloud/jdbc/jdbc/JdbcIgnoredStatements.java
@@ -1,0 +1,78 @@
+/**
+ * Copyright 2017-2018 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.opentracing.contrib.spring.cloud.jdbc.jdbc;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import io.opentracing.contrib.spring.cloud.jdbc.MockTracingConfiguration;
+import io.opentracing.mock.MockTracer;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import javax.sql.DataSource;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+/**
+ * Test behaviour when ignored statements are configured
+ * @author Will Penington
+ */
+@SpringBootTest(classes = {MockTracingConfiguration.class})
+@RunWith(SpringJUnit4ClassRunner.class)
+@TestPropertySource(properties = {
+        "opentracing.spring.cloud.jdbc.ignoreStatements=SELECT 1"
+})
+public class JdbcIgnoredStatements {
+
+  @Autowired
+  MockTracer tracer;
+
+  @Autowired
+  DataSource dataSource;
+
+  @Autowired
+  JdbcTemplate jdbcTemplate;
+
+  @Before
+  public void before() {
+    tracer.reset();
+  }
+
+  /**
+   * Make sure ignored statements aren't traced
+   */
+  @Test
+  public void spanIsNotCreatedForIgnoredStatement() throws SQLException {
+    PreparedStatement pstmt = dataSource.getConnection().prepareStatement("SELECT 1");
+    assertTrue(pstmt.execute());
+    assertEquals(0, tracer.finishedSpans().size());
+  }
+
+  /**
+   * Make sure statements that aren't ignored aren't affected
+   */
+  @Test
+  public void spanIsCreatedNonIgnoredStatement() throws SQLException {
+    PreparedStatement pstmt = dataSource.getConnection().prepareStatement("SELECT 2");
+    assertTrue(pstmt.execute());
+    assertEquals(1, tracer.finishedSpans().size());
+  }
+}

--- a/instrument-starters/opentracing-spring-cloud-jdbc-starter/src/test/java/io/opentracing/contrib/spring/cloud/jdbc/jdbc/JdbcOnlyWithActiveTest.java
+++ b/instrument-starters/opentracing-spring-cloud-jdbc-starter/src/test/java/io/opentracing/contrib/spring/cloud/jdbc/jdbc/JdbcOnlyWithActiveTest.java
@@ -1,0 +1,94 @@
+/**
+ * Copyright 2017-2018 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+
+package io.opentracing.contrib.spring.cloud.jdbc.jdbc;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import io.opentracing.Scope;
+import io.opentracing.contrib.spring.cloud.jdbc.MockTracingConfiguration;
+import io.opentracing.mock.MockSpan;
+import io.opentracing.mock.MockTracer;
+import io.opentracing.tag.Tags;
+import java.sql.PreparedStatement;
+import java.sql.SQLException;
+import java.util.Optional;
+import javax.sql.DataSource;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.jdbc.core.JdbcTemplate;
+import org.springframework.test.context.TestPropertySource;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+/**
+ * Test behaviour when withActiveSpanOnly is set
+ * @author Will Penington
+ */
+@SpringBootTest(classes = {MockTracingConfiguration.class})
+@RunWith(SpringJUnit4ClassRunner.class)
+@TestPropertySource(properties = {
+        "opentracing.spring.cloud.jdbc.withActiveSpanOnly=true"
+})
+public class JdbcOnlyWithActiveTest {
+
+  @Autowired
+  MockTracer tracer;
+
+  @Autowired
+  DataSource dataSource;
+
+  @Autowired
+  JdbcTemplate jdbcTemplate;
+
+  @Before
+  public void before() {
+    tracer.reset();
+  }
+
+  /**
+   * Make sure that a span is created when an active span exists.
+   */
+  @Test
+  public void spanJoinsActiveSpan() throws SQLException {
+    try (Scope ignored = tracer.buildSpan("parent").startActive(true)) {
+      assertTrue(dataSource.getConnection().prepareStatement("select 1").execute());
+      assertEquals(1, tracer.finishedSpans().size());
+    }
+
+    assertEquals(2, tracer.finishedSpans().size());
+
+    Optional<MockSpan> jdbcSpan = tracer
+            .finishedSpans()
+            .stream()
+            .filter((s) -> "java-jdbc".equals(s.tags().get(Tags.COMPONENT.getKey())))
+            .findFirst();
+
+    assertTrue(jdbcSpan.isPresent());
+  }
+
+  /**
+   * Make sure a new span is not created when there is no active parent span.
+   */
+  @Test
+  public void spanIsCreatedForPreparedStatement() throws SQLException {
+    PreparedStatement pstmt = dataSource.getConnection().prepareStatement("select 1");
+    assertTrue(pstmt.execute());
+    assertEquals(0, tracer.finishedSpans().size());
+  }
+
+}

--- a/instrument-starters/opentracing-spring-cloud-redis-starter/pom.xml
+++ b/instrument-starters/opentracing-spring-cloud-redis-starter/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2017-2018 The OpenTracing Authors
+    Copyright 2017-2019 The OpenTracing Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at
@@ -36,7 +36,18 @@
     </dependency>
     <dependency>
       <groupId>io.opentracing.contrib</groupId>
-      <artifactId>opentracing-redis-spring</artifactId>
+      <artifactId>opentracing-redis-spring-data</artifactId>
+      <version>${version.io.opentracing.contrib-opentracing-spring-redis}</version>
+      <exclusions>
+        <exclusion>
+          <artifactId>*</artifactId>
+          <groupId>*</groupId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>io.opentracing.contrib</groupId>
+      <artifactId>opentracing-redis-common</artifactId>
       <version>${version.io.opentracing.contrib-opentracing-spring-redis}</version>
       <exclusions>
         <exclusion>

--- a/instrument-starters/opentracing-spring-cloud-redis-starter/pom.xml
+++ b/instrument-starters/opentracing-spring-cloud-redis-starter/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2017-2019 The OpenTracing Authors
+    Copyright 2017-2018 The OpenTracing Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at

--- a/instrument-starters/opentracing-spring-cloud-redis-starter/pom.xml
+++ b/instrument-starters/opentracing-spring-cloud-redis-starter/pom.xml
@@ -1,0 +1,77 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2017-2019 The OpenTracing Authors
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+    in compliance with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the License
+    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+    or implied. See the License for the specific language governing permissions and limitations under
+    the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>opentracing-spring-cloud-parent</artifactId>
+    <groupId>io.opentracing.contrib</groupId>
+    <version>0.1.17-SNAPSHOT</version>
+    <relativePath>../../</relativePath>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>opentracing-spring-cloud-redis-starter</artifactId>
+
+  <properties>
+    <main.basedir>${project.basedir}/../..</main.basedir>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>io.opentracing.contrib</groupId>
+      <artifactId>opentracing-spring-tracer-configuration-starter</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.opentracing.contrib</groupId>
+      <artifactId>opentracing-redis-spring</artifactId>
+      <version>${version.io.opentracing.contrib-opentracing-spring-redis}</version>
+      <exclusions>
+        <exclusion>
+          <artifactId>*</artifactId>
+          <groupId>*</groupId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-aop</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-data-redis</artifactId>
+      <optional>true</optional>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>ai.grakn</groupId>
+      <artifactId>redis-mock</artifactId>
+      <version>0.1.6</version>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>redis.clients</groupId>
+      <artifactId>jedis</artifactId>
+      <version>2.9.0</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/instrument-starters/opentracing-spring-cloud-redis-starter/src/main/java/io/opentracing/contrib/spring/cloud/redis/RedisAspect.java
+++ b/instrument-starters/opentracing-spring-cloud-redis-starter/src/main/java/io/opentracing/contrib/spring/cloud/redis/RedisAspect.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2018 The OpenTracing Authors
+ * Copyright 2017-2019 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -13,8 +13,8 @@
  */
 package io.opentracing.contrib.spring.cloud.redis;
 
-import io.opentracing.contrib.redis.spring.connection.TracingRedisClusterConnection;
-import io.opentracing.contrib.redis.spring.connection.TracingRedisConnection;
+import io.opentracing.contrib.redis.spring.data.connection.TracingRedisClusterConnection;
+import io.opentracing.contrib.redis.spring.data.connection.TracingRedisConnection;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;

--- a/instrument-starters/opentracing-spring-cloud-redis-starter/src/main/java/io/opentracing/contrib/spring/cloud/redis/RedisAspect.java
+++ b/instrument-starters/opentracing-spring-cloud-redis-starter/src/main/java/io/opentracing/contrib/spring/cloud/redis/RedisAspect.java
@@ -1,0 +1,71 @@
+/**
+ * Copyright 2017-2019 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.contrib.spring.cloud.redis;
+
+import io.opentracing.contrib.redis.spring.connection.TracingRedisClusterConnection;
+import io.opentracing.contrib.redis.spring.connection.TracingRedisConnection;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.annotation.Pointcut;
+import org.springframework.data.redis.connection.RedisClusterConnection;
+import org.springframework.data.redis.connection.RedisConnection;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+
+/**
+ * Spring AOP Aspect wrapping Redis-related calls, delegating as much as possible to the official
+ * OpenTracing Java Redis framework integration.
+ *
+ * @author Daniel del Castillo
+ */
+@Aspect
+public class RedisAspect {
+
+  @Pointcut("target(org.springframework.data.redis.connection.RedisConnectionFactory)")
+  public void connectionFactory() {}
+
+  @Pointcut("execution(org.springframework.data.redis.connection.RedisConnection *.getConnection(..))")
+  public void getConnection() {}
+
+  @Pointcut("execution(org.springframework.data.redis.connection.RedisClusterConnection *.getClusterConnection(..))")
+  public void getClusterConnection() {}
+
+
+  /**
+   * Intercepts calls to {@link RedisConnectionFactory#getConnection()} (and related), wrapping the
+   * outcome in a {@link TracingRedisConnection}
+   *
+   * @param pjp the intercepted join point
+   * @return a new {@link TracingRedisConnection} wrapping the result of the joint point
+   */
+  @Around("getConnection() && connectionFactory()")
+  public Object aroundGetConnection(final ProceedingJoinPoint pjp) throws Throwable {
+    RedisConnection connection = (RedisConnection) pjp.proceed();
+    return new TracingRedisConnection(connection, false, null);
+  }
+
+  /**
+   * Intercepts calls to {@link RedisConnectionFactory#getClusterConnection()} (and related),
+   * wrapping the outcome in a {@link TracingRedisClusterConnection}
+   *
+   * @param pjp the intercepted join point
+   * @return a new {@link TracingRedisClusterConnection} wrapping the result of the joint point
+   */
+  @Around("getClusterConnection() && connectionFactory()")
+  public Object aroundGetClusterConnection(final ProceedingJoinPoint pjp) throws Throwable {
+    RedisClusterConnection clusterConnection = (RedisClusterConnection) pjp.proceed();
+    return new TracingRedisClusterConnection(clusterConnection, false, null);
+  }
+
+}

--- a/instrument-starters/opentracing-spring-cloud-redis-starter/src/main/java/io/opentracing/contrib/spring/cloud/redis/RedisAspect.java
+++ b/instrument-starters/opentracing-spring-cloud-redis-starter/src/main/java/io/opentracing/contrib/spring/cloud/redis/RedisAspect.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2019 The OpenTracing Authors
+ * Copyright 2017-2018 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/instrument-starters/opentracing-spring-cloud-redis-starter/src/main/java/io/opentracing/contrib/spring/cloud/redis/RedisAutoConfiguration.java
+++ b/instrument-starters/opentracing-spring-cloud-redis-starter/src/main/java/io/opentracing/contrib/spring/cloud/redis/RedisAutoConfiguration.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2018 The OpenTracing Authors
+ * Copyright 2017-2019 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/instrument-starters/opentracing-spring-cloud-redis-starter/src/main/java/io/opentracing/contrib/spring/cloud/redis/RedisAutoConfiguration.java
+++ b/instrument-starters/opentracing-spring-cloud-redis-starter/src/main/java/io/opentracing/contrib/spring/cloud/redis/RedisAutoConfiguration.java
@@ -1,0 +1,40 @@
+/**
+ * Copyright 2017-2019 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.contrib.spring.cloud.redis;
+
+import io.opentracing.contrib.spring.tracer.configuration.TracerRegisterAutoConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+
+/**
+ * Loads the integration with OpenTracing Redis if it's included in the classpath.
+ *
+ * @author Daniel del Castillo
+ */
+@Configuration
+@AutoConfigureAfter(TracerRegisterAutoConfiguration.class)
+@ConditionalOnBean(RedisConnectionFactory.class)
+@ConditionalOnProperty(name = "opentracing.spring.cloud.redis.enabled", havingValue = "true", matchIfMissing = true)
+public class RedisAutoConfiguration {
+
+  @Bean
+  public RedisAspect openTracingRedisAspect() {
+    return new RedisAspect();
+  }
+
+}

--- a/instrument-starters/opentracing-spring-cloud-redis-starter/src/main/java/io/opentracing/contrib/spring/cloud/redis/RedisAutoConfiguration.java
+++ b/instrument-starters/opentracing-spring-cloud-redis-starter/src/main/java/io/opentracing/contrib/spring/cloud/redis/RedisAutoConfiguration.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2019 The OpenTracing Authors
+ * Copyright 2017-2018 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/instrument-starters/opentracing-spring-cloud-redis-starter/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/instrument-starters/opentracing-spring-cloud-redis-starter/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,10 @@
+{
+  "properties": [
+    {
+      "name": "opentracing.spring.cloud.redis.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Enable Redis tracing.",
+      "defaultValue": true
+    }
+  ]
+}

--- a/instrument-starters/opentracing-spring-cloud-redis-starter/src/main/resources/META-INF/spring.factories
+++ b/instrument-starters/opentracing-spring-cloud-redis-starter/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+io.opentracing.contrib.spring.cloud.redis.RedisAutoConfiguration

--- a/instrument-starters/opentracing-spring-cloud-redis-starter/src/test/java/io/opentracing/contrib/spring/cloud/redis/IntegrationTest.java
+++ b/instrument-starters/opentracing-spring-cloud-redis-starter/src/test/java/io/opentracing/contrib/spring/cloud/redis/IntegrationTest.java
@@ -89,11 +89,9 @@ public class IntegrationTest {
 
   @Test
   public void commandCreatesNewSpan() {
-    // TODO this fails on SB 1.5
     redisTemplate.opsForValue().set(100L, "Some value here");
     assertEquals(1, tracer.finishedSpans().size());
-    // TODO it's null here, but in SB 2.x it works
-    // assertEquals("SET", tracer.finishedSpans().get(0).tags().get("command"));
+    assertEquals("SET", tracer.finishedSpans().get(0).operationName());
   }
 
   @Test
@@ -101,8 +99,7 @@ public class IntegrationTest {
     try (Scope ignored = tracer.buildSpan("parent").startActive(true)) {
       redisTemplate.opsForList().leftPushAll("test-list", 1, 2, 3);
       assertEquals(1, tracer.finishedSpans().size());
-      // TODO it's null here, but in SB 2.x it works
-      // assertEquals("LPUSH", tracer.finishedSpans().get(0).tags().get("command"));
+      assertEquals("LPUSH", tracer.finishedSpans().get(0).operationName());
     }
 
     assertEquals(2, tracer.finishedSpans().size());

--- a/instrument-starters/opentracing-spring-cloud-redis-starter/src/test/java/io/opentracing/contrib/spring/cloud/redis/IntegrationTest.java
+++ b/instrument-starters/opentracing-spring-cloud-redis-starter/src/test/java/io/opentracing/contrib/spring/cloud/redis/IntegrationTest.java
@@ -1,0 +1,122 @@
+/**
+ * Copyright 2017-2019 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.contrib.spring.cloud.redis;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import ai.grakn.redismock.RedisServer;
+import io.opentracing.Scope;
+import io.opentracing.mock.MockSpan;
+import io.opentracing.mock.MockTracer;
+import io.opentracing.tag.Tags;
+import io.opentracing.util.GlobalTracerTestUtil;
+import java.util.Optional;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.jedis.JedisConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+/**
+ * @author Daniel del Castillo
+ */
+@SpringBootTest(classes = {IntegrationTest.IntegrationTestConfiguration.class})
+@RunWith(SpringJUnit4ClassRunner.class)
+public class IntegrationTest {
+
+  @Configuration
+  @EnableAutoConfiguration
+  public static class IntegrationTestConfiguration {
+
+    public @Bean MockTracer mockTracer() {
+      GlobalTracerTestUtil.resetGlobalTracer();
+      return new MockTracer();
+    }
+
+    public @Bean RedisConnectionFactory redisConnectionFactory() {
+      JedisConnectionFactory jedisConnectionFactory = new JedisConnectionFactory();
+      jedisConnectionFactory.setHostName(redis.getHost());
+      jedisConnectionFactory.setPort(redis.getBindPort());
+      return jedisConnectionFactory;
+    }
+
+  }
+
+  private static RedisServer redis;
+
+  @Autowired
+  MockTracer tracer;
+
+  @Autowired
+  RedisTemplate redisTemplate;
+
+  @BeforeClass
+  public static void setup() throws Exception {
+    redis = RedisServer.newRedisServer();
+    redis.start();
+  }
+
+  @AfterClass
+  public static void teardown() {
+    redis.stop();
+  }
+
+  @Before
+  public void init() {
+    tracer.reset();
+  }
+
+  @Test
+  public void commandCreatesNewSpan() {
+    // TODO this fails on SB 1.5
+    redisTemplate.opsForValue().set(100L, "Some value here");
+    assertEquals(1, tracer.finishedSpans().size());
+    assertEquals("SET", tracer.finishedSpans().get(0).tags().get("command"));
+  }
+
+  @Test
+  public void spanJoinsActiveSpan() {
+    try (Scope ignored = tracer.buildSpan("parent").startActive(true)) {
+      redisTemplate.opsForList().leftPushAll("test-list", 1, 2, 3);
+      assertEquals(1, tracer.finishedSpans().size());
+      assertEquals("LPUSH", tracer.finishedSpans().get(0).tags().get("command"));
+    }
+
+    assertEquals(2, tracer.finishedSpans().size());
+    Optional<MockSpan> redisSpan = tracer.finishedSpans().stream()
+        .filter((s) -> "java-redis".equals(s.tags().get(Tags.COMPONENT.getKey()))).findFirst();
+
+    Optional<MockSpan> parentSpan =
+        tracer.finishedSpans().stream().filter((s) -> "parent".equals(s.operationName())).findFirst();
+
+    assertTrue(redisSpan.isPresent());
+    assertTrue(parentSpan.isPresent());
+
+    assertEquals(redisSpan.get().context().traceId(), parentSpan.get().context().traceId());
+    assertEquals(redisSpan.get().parentId(), parentSpan.get().context().spanId());
+  }
+
+  // Cluster operations can be tested once https://github.com/kstyrc/embedded-redis/issues/79 is fixed
+
+}

--- a/instrument-starters/opentracing-spring-cloud-redis-starter/src/test/java/io/opentracing/contrib/spring/cloud/redis/IntegrationTest.java
+++ b/instrument-starters/opentracing-spring-cloud-redis-starter/src/test/java/io/opentracing/contrib/spring/cloud/redis/IntegrationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2019 The OpenTracing Authors
+ * Copyright 2017-2018 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/instrument-starters/opentracing-spring-cloud-redis-starter/src/test/java/io/opentracing/contrib/spring/cloud/redis/IntegrationTest.java
+++ b/instrument-starters/opentracing-spring-cloud-redis-starter/src/test/java/io/opentracing/contrib/spring/cloud/redis/IntegrationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2018 The OpenTracing Authors
+ * Copyright 2017-2019 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -92,7 +92,8 @@ public class IntegrationTest {
     // TODO this fails on SB 1.5
     redisTemplate.opsForValue().set(100L, "Some value here");
     assertEquals(1, tracer.finishedSpans().size());
-    assertEquals("SET", tracer.finishedSpans().get(0).tags().get("command"));
+    // TODO it's null here, but in SB 2.x it works
+    // assertEquals("SET", tracer.finishedSpans().get(0).tags().get("command"));
   }
 
   @Test
@@ -100,7 +101,8 @@ public class IntegrationTest {
     try (Scope ignored = tracer.buildSpan("parent").startActive(true)) {
       redisTemplate.opsForList().leftPushAll("test-list", 1, 2, 3);
       assertEquals(1, tracer.finishedSpans().size());
-      assertEquals("LPUSH", tracer.finishedSpans().get(0).tags().get("command"));
+      // TODO it's null here, but in SB 2.x it works
+      // assertEquals("LPUSH", tracer.finishedSpans().get(0).tags().get("command"));
     }
 
     assertEquals(2, tracer.finishedSpans().size());

--- a/opentracing-spring-cloud-starter/pom.xml
+++ b/opentracing-spring-cloud-starter/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2017-2018 The OpenTracing Authors
+    Copyright 2017-2019 The OpenTracing Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at

--- a/opentracing-spring-cloud-starter/pom.xml
+++ b/opentracing-spring-cloud-starter/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2017-2018 The OpenTracing Authors
+    Copyright 2017-2019 The OpenTracing Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at
@@ -65,6 +65,10 @@
     <dependency>
       <groupId>${project.groupId}</groupId>
       <artifactId>opentracing-spring-cloud-rxjava-starter</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
+      <artifactId>opentracing-spring-cloud-redis-starter</artifactId>
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>

--- a/opentracing-spring-cloud-starter/pom.xml
+++ b/opentracing-spring-cloud-starter/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2017-2019 The OpenTracing Authors
+    Copyright 2017-2018 The OpenTracing Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at

--- a/opentracing-spring-cloud-starter/src/test/java/io/opentracing/contrib/spring/cloud/NoDepsTest.java
+++ b/opentracing-spring-cloud-starter/src/test/java/io/opentracing/contrib/spring/cloud/NoDepsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2018 The OpenTracing Authors
+ * Copyright 2017-2019 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/opentracing-spring-cloud-starter/src/test/java/io/opentracing/contrib/spring/cloud/NoDepsTest.java
+++ b/opentracing-spring-cloud-starter/src/test/java/io/opentracing/contrib/spring/cloud/NoDepsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2018 The OpenTracing Authors
+ * Copyright 2017-2019 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -48,6 +48,21 @@ public class NoDepsTest {
   @Test(expected = ClassNotFoundException.class)
   public void testNoRxJavaHooks() throws ClassNotFoundException {
     this.getClass().getClassLoader().loadClass("rx.plugins.RxJavaHooks");
+  }
+
+  @Test(expected = ClassNotFoundException.class)
+  public void testNoRedisJavaHooks() throws ClassNotFoundException {
+    this.getClass().getClassLoader().loadClass("org.springframework.data.redis.core.RedisTemplate");
+  }
+
+  @Test(expected = ClassNotFoundException.class)
+  public void testNoJedisClient() throws ClassNotFoundException {
+    this.getClass().getClassLoader().loadClass("redis.clients.jedis.Client");
+  }
+
+  @Test(expected = ClassNotFoundException.class)
+  public void testNoLettuceClient() throws ClassNotFoundException {
+    this.getClass().getClassLoader().loadClass("io.lettuce.core.RedisClient");
   }
 
   @Test(expected = ClassNotFoundException.class)

--- a/opentracing-spring-cloud-starter/src/test/java/io/opentracing/contrib/spring/cloud/NoDepsTest.java
+++ b/opentracing-spring-cloud-starter/src/test/java/io/opentracing/contrib/spring/cloud/NoDepsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2019 The OpenTracing Authors
+ * Copyright 2017-2018 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/pom.xml
+++ b/pom.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2017-2018 The OpenTracing Authors
+    Copyright 2017-2019 The OpenTracing Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at
@@ -31,6 +31,7 @@
     <module>instrument-starters/opentracing-spring-cloud-zuul-starter</module>
     <module>instrument-starters/opentracing-spring-cloud-hystrix-starter</module>
     <module>instrument-starters/opentracing-spring-cloud-rxjava-starter</module>
+    <module>instrument-starters/opentracing-spring-cloud-redis-starter</module>
   </modules>
   <packaging>pom</packaging>
 
@@ -75,7 +76,8 @@
     <version.io.opentracing.contrib-opentracing-spring-jms>0.0.8</version.io.opentracing.contrib-opentracing-spring-jms>
     <version.io.opentracing.contrib-opentracing-spring-messaging>0.0.5</version.io.opentracing.contrib-opentracing-spring-messaging>
     <version.io.opentracing.contrib-opentracing-spring-rabbitmq>0.1.0</version.io.opentracing.contrib-opentracing-spring-rabbitmq>
-    <version.io.opentracing.contrib-java-jdbc>0.0.7</version.io.opentracing.contrib-java-jdbc>
+    <version.io.opentracing.contrib-java-jdbc>0.0.9</version.io.opentracing.contrib-java-jdbc>
+    <version.io.opentracing.contrib-opentracing-spring-redis>0.0.10</version.io.opentracing.contrib-opentracing-spring-redis>
     <version.io.opentracing.contrib-java-concurrent>0.1.0</version.io.opentracing.contrib-java-concurrent>
     <version.io.opentracing.contrib-opentracing-rxjava-1>0.0.7</version.io.opentracing.contrib-opentracing-rxjava-1>
     <version.io.opentracing.contrib-opentracing-spring-mongo>0.0.4</version.io.opentracing.contrib-opentracing-spring-mongo>
@@ -140,6 +142,11 @@
       <dependency>
         <groupId>${project.groupId}</groupId>
         <artifactId>opentracing-spring-cloud-rxjava-starter</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>${project.groupId}</groupId>
+        <artifactId>opentracing-spring-cloud-redis-starter</artifactId>
         <version>${project.version}</version>
       </dependency>
       <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
     <version.io.opentracing.contrib-opentracing-spring-messaging>0.0.5</version.io.opentracing.contrib-opentracing-spring-messaging>
     <version.io.opentracing.contrib-opentracing-spring-rabbitmq>0.1.0</version.io.opentracing.contrib-opentracing-spring-rabbitmq>
     <version.io.opentracing.contrib-java-jdbc>0.0.9</version.io.opentracing.contrib-java-jdbc>
-    <version.io.opentracing.contrib-opentracing-spring-redis>0.0.7</version.io.opentracing.contrib-opentracing-spring-redis>
+    <version.io.opentracing.contrib-opentracing-spring-redis>0.0.16</version.io.opentracing.contrib-opentracing-spring-redis>
     <version.io.opentracing.contrib-java-concurrent>0.1.0</version.io.opentracing.contrib-java-concurrent>
     <version.io.opentracing.contrib-opentracing-rxjava-1>0.0.7</version.io.opentracing.contrib-opentracing-rxjava-1>
     <version.io.opentracing.contrib-opentracing-spring-mongo>0.0.4</version.io.opentracing.contrib-opentracing-spring-mongo>

--- a/pom.xml
+++ b/pom.xml
@@ -77,7 +77,7 @@
     <version.io.opentracing.contrib-opentracing-spring-messaging>0.0.5</version.io.opentracing.contrib-opentracing-spring-messaging>
     <version.io.opentracing.contrib-opentracing-spring-rabbitmq>0.1.0</version.io.opentracing.contrib-opentracing-spring-rabbitmq>
     <version.io.opentracing.contrib-java-jdbc>0.0.9</version.io.opentracing.contrib-java-jdbc>
-    <version.io.opentracing.contrib-opentracing-spring-redis>0.0.10</version.io.opentracing.contrib-opentracing-spring-redis>
+    <version.io.opentracing.contrib-opentracing-spring-redis>0.0.7</version.io.opentracing.contrib-opentracing-spring-redis>
     <version.io.opentracing.contrib-java-concurrent>0.1.0</version.io.opentracing.contrib-java-concurrent>
     <version.io.opentracing.contrib-opentracing-rxjava-1>0.0.7</version.io.opentracing.contrib-opentracing-rxjava-1>
     <version.io.opentracing.contrib-opentracing-spring-mongo>0.0.4</version.io.opentracing.contrib-opentracing-spring-mongo>

--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
     <version.io.opentracing.contrib-opentracing-spring-jms>0.0.8</version.io.opentracing.contrib-opentracing-spring-jms>
     <version.io.opentracing.contrib-opentracing-spring-messaging>0.0.5</version.io.opentracing.contrib-opentracing-spring-messaging>
     <version.io.opentracing.contrib-opentracing-spring-rabbitmq>0.1.0</version.io.opentracing.contrib-opentracing-spring-rabbitmq>
-    <version.io.opentracing.contrib-java-jdbc>0.0.6</version.io.opentracing.contrib-java-jdbc>
+    <version.io.opentracing.contrib-java-jdbc>0.0.7</version.io.opentracing.contrib-java-jdbc>
     <version.io.opentracing.contrib-java-concurrent>0.1.0</version.io.opentracing.contrib-java-concurrent>
     <version.io.opentracing.contrib-opentracing-rxjava-1>0.0.7</version.io.opentracing.contrib-opentracing-rxjava-1>
     <version.io.opentracing.contrib-opentracing-spring-mongo>0.0.4</version.io.opentracing.contrib-opentracing-spring-mongo>


### PR DESCRIPTION
Resolves #69 

At the moment it's blocked by https://github.com/opentracing-contrib/java-redis-client/issues/28. The redis instrumentation fails on SB 1.x.

@malafeev any workarounds are appreciated.