### PR TITLE
Add Spring Boot autoconfiguration for Reactor instrumentation.

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This repository provides OpenTracing instrumentation for Spring Boot and its var
 compatible implementation.
 
 It contains auto-configurations which instruments and trace following Spring Boot projects:
-* Spring Web (RestControllers, RestTemplates, WebAsyncTask)
+* Spring Web (RestControllers, RestTemplates, WebAsyncTask, WebClient, WebFlux)
 * @Async, @Scheduled, Executors
 * WebSocket STOMP
 * Feign, HystrixFeign
@@ -14,6 +14,7 @@ It contains auto-configurations which instruments and trace following Spring Boo
 * JDBC
 * Mongo
 * Zuul
+* Reactor
 * RxJava
 * Redis
 * Standard logging - logs are added to active span

--- a/instrument-starters/opentracing-spring-cloud-reactor-starter/pom.xml
+++ b/instrument-starters/opentracing-spring-cloud-reactor-starter/pom.xml
@@ -1,0 +1,76 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2017-2019 The OpenTracing Authors
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+    in compliance with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the License
+    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+    or implied. See the License for the specific language governing permissions and limitations under
+    the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>opentracing-spring-cloud-parent</artifactId>
+    <groupId>io.opentracing.contrib</groupId>
+    <version>0.2.5-SNAPSHOT</version>
+    <relativePath>../../</relativePath>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>opentracing-spring-cloud-reactor-starter</artifactId>
+
+  <properties>
+    <main.basedir>${project.basedir}/../..</main.basedir>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-autoconfigure</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.opentracing.contrib</groupId>
+      <artifactId>opentracing-spring-tracer-configuration-starter</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.opentracing.contrib</groupId>
+      <artifactId>opentracing-concurrent</artifactId>
+      <version>${version.io.opentracing.contrib-java-concurrent}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.opentracing.contrib</groupId>
+      <artifactId>opentracing-reactor</artifactId>
+      <version>${version.io.opentracing.contrib-opentracing-reactor}</version>
+    </dependency>
+    <dependency>
+      <groupId>io.projectreactor</groupId>
+      <artifactId>reactor-core</artifactId>
+      <version>${version.reactor-core}</version>
+      <optional>true</optional>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-web</artifactId>
+      <scope>test</scope>
+    </dependency>
+    <dependency>
+      <groupId>io.opentracing.contrib</groupId>
+      <artifactId>opentracing-spring-web-starter</artifactId>
+      <version>${version.io.opentracing.contrib-opentracing-spring-web}</version>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+</project>

--- a/instrument-starters/opentracing-spring-cloud-reactor-starter/src/main/java/io/opentracing/contrib/spring/cloud/reactor/ReactorTracingAutoConfiguration.java
+++ b/instrument-starters/opentracing-spring-cloud-reactor-starter/src/main/java/io/opentracing/contrib/spring/cloud/reactor/ReactorTracingAutoConfiguration.java
@@ -1,0 +1,63 @@
+/*
+ * Copyright 2013-2019 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package io.opentracing.contrib.spring.cloud.reactor;
+
+import io.opentracing.Tracer;
+import io.opentracing.contrib.concurrent.TracedScheduledExecutorService;
+import io.opentracing.contrib.reactor.TracedSubscriber;
+import io.opentracing.contrib.spring.tracer.configuration.TracerAutoConfiguration;
+import javax.annotation.PreDestroy;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Configuration;
+import reactor.core.publisher.Hooks;
+import reactor.core.scheduler.Schedulers;
+
+/**
+ * Spring Boot auto-configuration to enable tracing of Reactor components.
+ *
+ * Similar to {@code TraceReactorAutoConfiguration} from spring-cloud-sleuth.
+ *
+ * @author Csaba Kos
+ */
+@Configuration
+@AutoConfigureAfter(TracerAutoConfiguration.class)
+@ConditionalOnBean(Tracer.class)
+@ConditionalOnClass(Hooks.class)
+@ConditionalOnProperty(name = "opentracing.spring.cloud.reactor.enabled", havingValue = "true", matchIfMissing = true)
+public class ReactorTracingAutoConfiguration {
+  private static final String EXECUTOR_SERVICE_DECORATOR_KEY = ReactorTracingAutoConfiguration.class.getName();
+  private static final String HOOK_KEY = ReactorTracingAutoConfiguration.class.getName();
+
+  @Autowired
+  public ReactorTracingAutoConfiguration(final Tracer tracer) {
+    Hooks.onEachOperator(HOOK_KEY, TracedSubscriber.asOperator(tracer));
+    Schedulers.setExecutorServiceDecorator(
+        EXECUTOR_SERVICE_DECORATOR_KEY,
+        (scheduler, scheduledExecutorService) ->
+            new TracedScheduledExecutorService(scheduledExecutorService, tracer)
+    );
+  }
+
+  @PreDestroy
+  public void cleanupHooks() {
+    Hooks.resetOnEachOperator(HOOK_KEY);
+    Schedulers.removeExecutorServiceDecorator(EXECUTOR_SERVICE_DECORATOR_KEY);
+  }
+}

--- a/instrument-starters/opentracing-spring-cloud-reactor-starter/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/instrument-starters/opentracing-spring-cloud-reactor-starter/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,10 @@
+{
+  "properties": [
+    {
+      "name": "opentracing.spring.cloud.reactor.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Enable Reactor tracing.",
+      "defaultValue": true
+    }
+  ]
+}

--- a/instrument-starters/opentracing-spring-cloud-reactor-starter/src/main/resources/META-INF/spring.factories
+++ b/instrument-starters/opentracing-spring-cloud-reactor-starter/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,3 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+io.opentracing.contrib.spring.cloud.reactor.ReactorTracingAutoConfiguration
+

--- a/instrument-starters/opentracing-spring-cloud-reactor-starter/src/test/java/io/opentracing/contrib/spring/cloud/reactor/ReactorTracingAutoConfigurationTest.java
+++ b/instrument-starters/opentracing-spring-cloud-reactor-starter/src/test/java/io/opentracing/contrib/spring/cloud/reactor/ReactorTracingAutoConfigurationTest.java
@@ -1,0 +1,102 @@
+/**
+ * Copyright 2017-2019 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.contrib.spring.cloud.reactor;
+
+import static org.awaitility.Awaitility.await;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotNull;
+
+import io.opentracing.contrib.spring.cloud.reactor.ReactorTracingAutoConfigurationTest.MockTracingConfiguration;
+import io.opentracing.contrib.spring.cloud.reactor.ReactorTracingAutoConfigurationTest.TestController;
+import io.opentracing.mock.MockSpan;
+import io.opentracing.mock.MockTracer;
+import java.util.List;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.boot.test.context.SpringBootTest.WebEnvironment;
+import org.springframework.boot.test.web.client.TestRestTemplate;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.http.ResponseEntity;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+import org.springframework.web.bind.annotation.RequestMapping;
+import org.springframework.web.bind.annotation.RequestMethod;
+import org.springframework.web.bind.annotation.RestController;
+import reactor.core.publisher.Flux;
+import reactor.core.publisher.Mono;
+import reactor.core.scheduler.Schedulers;
+
+@SpringBootTest(
+    webEnvironment = WebEnvironment.RANDOM_PORT,
+    classes = {MockTracingConfiguration.class, TestController.class},
+    properties = {"opentracing.spring.web.client.enabled=false"})
+@RunWith(SpringJUnit4ClassRunner.class)
+public class ReactorTracingAutoConfigurationTest {
+
+  @Configuration
+  @EnableAutoConfiguration
+  public static class MockTracingConfiguration {
+    @Bean
+    public MockTracer tracer() {
+      return new MockTracer();
+    }
+  }
+
+  @RestController
+  public static class TestController {
+
+    @Autowired
+    private MockTracer mockTracer;
+
+    @RequestMapping(method = RequestMethod.GET, value = "/single")
+    public Mono<Integer> single() {
+      return Flux.range(1, 10)
+          .subscribeOn(Schedulers.elastic())
+          .publishOn(Schedulers.parallel())
+          .map(x -> {
+            // without enabled Reactor instrumentation active span will be null
+            assertNotNull(mockTracer.activeSpan());
+            mockTracer.activeSpan().setTag("reactor", "reactor");
+            return x * 2;
+          }).take(1).single();
+    }
+  }
+
+  @Autowired
+  private MockTracer mockTracer;
+
+  @Autowired
+  private TestRestTemplate testRestTemplate;
+
+  @Before
+  public void before() {
+    mockTracer.reset();
+  }
+
+  @Test
+  public void testControllerTracing() throws Exception {
+    ResponseEntity<String> responseEntity = testRestTemplate.getForEntity("/single", String.class);
+
+    // span is created in spring-web
+    await().until(() -> mockTracer.finishedSpans().size() == 1);
+    assertEquals(200, responseEntity.getStatusCode().value());
+    List<MockSpan> spans = mockTracer.finishedSpans();
+    assertEquals(1, spans.size());
+    assertEquals("reactor", spans.get(0).tags().get("reactor"));
+  }
+}

--- a/opentracing-spring-cloud-starter/pom.xml
+++ b/opentracing-spring-cloud-starter/pom.xml
@@ -64,6 +64,10 @@
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
+      <artifactId>opentracing-spring-cloud-reactor-starter</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
       <artifactId>opentracing-spring-cloud-rxjava-starter</artifactId>
     </dependency>
     <dependency>

--- a/pom.xml
+++ b/pom.xml
@@ -73,7 +73,7 @@
 
     <version.io.opentracing>0.31.0</version.io.opentracing>
     <version.io.opentracing.contrib-opentracing-spring-tracer-configuration-starter>0.1.0</version.io.opentracing.contrib-opentracing-spring-tracer-configuration-starter>
-    <version.io.opentracing.contrib-opentracing-spring-web>0.3.4</version.io.opentracing.contrib-opentracing-spring-web>
+    <version.io.opentracing.contrib-opentracing-spring-web>1.1.1</version.io.opentracing.contrib-opentracing-spring-web>
     <version.io.opentracing.contrib-opentracing-spring-jms>0.0.10</version.io.opentracing.contrib-opentracing-spring-jms>
     <version.io.opentracing.contrib-opentracing-spring-messaging>0.0.5</version.io.opentracing.contrib-opentracing-spring-messaging>
     <version.io.opentracing.contrib-opentracing-spring-rabbitmq>0.1.1</version.io.opentracing.contrib-opentracing-spring-rabbitmq>

--- a/pom.xml
+++ b/pom.xml
@@ -30,6 +30,7 @@
     <module>instrument-starters/opentracing-spring-cloud-websocket-starter</module>
     <module>instrument-starters/opentracing-spring-cloud-zuul-starter</module>
     <module>instrument-starters/opentracing-spring-cloud-hystrix-starter</module>
+    <module>instrument-starters/opentracing-spring-cloud-reactor-starter</module>
     <module>instrument-starters/opentracing-spring-cloud-rxjava-starter</module>
     <module>instrument-starters/opentracing-spring-cloud-redis-starter</module>
   </modules>
@@ -78,7 +79,8 @@
     <version.io.opentracing.contrib-opentracing-spring-rabbitmq>0.1.1</version.io.opentracing.contrib-opentracing-spring-rabbitmq>
     <version.io.opentracing.contrib-java-jdbc>0.0.12</version.io.opentracing.contrib-java-jdbc>
     <version.io.opentracing.contrib-opentracing-spring-redis>0.0.10</version.io.opentracing.contrib-opentracing-spring-redis>
-    <version.io.opentracing.contrib-java-concurrent>0.1.0</version.io.opentracing.contrib-java-concurrent>
+    <version.io.opentracing.contrib-java-concurrent>0.2.0</version.io.opentracing.contrib-java-concurrent>
+    <version.io.opentracing.contrib-opentracing-reactor>0.0.2</version.io.opentracing.contrib-opentracing-reactor>
     <version.io.opentracing.contrib-opentracing-rxjava-1>0.0.9</version.io.opentracing.contrib-opentracing-rxjava-1>
     <version.io.opentracing.contrib-opentracing-spring-mongo>0.0.6</version.io.opentracing.contrib-opentracing-spring-mongo>
     <version.io.github.openfeign-feign-okhttp>9.5.0</version.io.github.openfeign-feign-okhttp>
@@ -91,6 +93,7 @@
     <version.de.flapdoodle-embed.mongo>2.0.3</version.de.flapdoodle-embed.mongo>
     <version.cz.jirutka.spring-embedmongo-spring>1.3.1</version.cz.jirutka.spring-embedmongo-spring>
     <version.org.slf4j-log4j-over-slf4j>1.7.25</version.org.slf4j-log4j-over-slf4j>
+    <version.reactor-core>3.2.3.RELEASE</version.reactor-core>
 
     <version.javax.jms>1.1-rev-1</version.javax.jms>
 
@@ -138,6 +141,11 @@
       <dependency>
         <groupId>${project.groupId}</groupId>
         <artifactId>opentracing-spring-cloud-hystrix-starter</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>${project.groupId}</groupId>
+        <artifactId>opentracing-spring-cloud-reactor-starter</artifactId>
         <version>${project.version}</version>
       </dependency>
       <dependency>
@@ -380,6 +388,7 @@
             <exclude>**/ExecutorBeanPostProcessor.java</exclude>
             <exclude>**/TraceEnvironmentPostProcessor.java</exclude>
             <exclude>**/test/resources/application.yml</exclude>
+            <exclude>**/ReactorTracingAutoConfiguration.java</exclude>
           </excludes>
         </configuration>
         <dependencies>


### PR DESCRIPTION
This completes the WebFlux/WebClient instrumentation introduced in [java-spring-web#95](https://github.com/opentracing-contrib/java-spring-web/pull/95) and relies on the [recently published](https://github.com/opentracing-contrib/java-reactor/issues/1) `java-reactor` instrumentation.

I used the existing rxjava starter as a template (including the tests).