### PR TITLE
Bump OpenTracing to 0.32.0

### DIFF
--- a/instrument-starters/opentracing-spring-cloud-core/src/main/java/io/opentracing/contrib/spring/cloud/async/TraceAsyncAspect.java
+++ b/instrument-starters/opentracing-spring-cloud-core/src/main/java/io/opentracing/contrib/spring/cloud/async/TraceAsyncAspect.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2018 The OpenTracing Authors
+ * Copyright 2017-2019 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -52,7 +52,7 @@ public class TraceAsyncAspect {
         .withTag(ExtensionTags.CLASS_TAG.getKey(), pjp.getTarget().getClass().getSimpleName())
         .withTag(ExtensionTags.METHOD_TAG.getKey(), pjp.getSignature().getName())
         .start();
-    try (Scope scope = this.tracer.scopeManager().activate(span, false)) {
+    try (Scope scope = this.tracer.scopeManager().activate(span)) {
       return pjp.proceed();
     } catch (Exception ex) {
       SpanUtils.captureException(span, ex);

--- a/instrument-starters/opentracing-spring-cloud-core/src/main/java/io/opentracing/contrib/spring/cloud/scheduled/ScheduledAspect.java
+++ b/instrument-starters/opentracing-spring-cloud-core/src/main/java/io/opentracing/contrib/spring/cloud/scheduled/ScheduledAspect.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2018 The OpenTracing Authors
+ * Copyright 2017-2019 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -14,6 +14,7 @@
 package io.opentracing.contrib.spring.cloud.scheduled;
 
 import io.opentracing.Scope;
+import io.opentracing.Span;
 import io.opentracing.Tracer;
 import io.opentracing.contrib.spring.cloud.ExtensionTags;
 import io.opentracing.contrib.spring.cloud.SpanUtils;
@@ -46,18 +47,20 @@ public class ScheduledAspect {
     }
 
     // operation name is method name
-    Scope scope = tracer.buildSpan(pjp.getSignature().getName())
+    Span span = tracer.buildSpan(pjp.getSignature().getName())
         .withTag(Tags.COMPONENT.getKey(), COMPONENT_NAME)
         .withTag(ExtensionTags.CLASS_TAG.getKey(), pjp.getTarget().getClass().getSimpleName())
         .withTag(ExtensionTags.METHOD_TAG.getKey(), pjp.getSignature().getName())
-        .startActive(true);
+        .start();
     try {
-      return pjp.proceed();
+      try (Scope scope = tracer.activateSpan(span)) {
+        return pjp.proceed();
+      }
     } catch (Exception ex) {
-      SpanUtils.captureException(scope.span(), ex);
+      SpanUtils.captureException(span, ex);
       throw ex;
     } finally {
-      scope.close();
+      span.finish();
     }
   }
 }

--- a/instrument-starters/opentracing-spring-cloud-core/src/test/java/io/opentracing/contrib/spring/cloud/async/WebAsyncTaskTest.java
+++ b/instrument-starters/opentracing-spring-cloud-core/src/test/java/io/opentracing/contrib/spring/cloud/async/WebAsyncTaskTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2018 The OpenTracing Authors
+ * Copyright 2017-2019 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -52,7 +52,7 @@ public class WebAsyncTaskTest {
     @RequestMapping("/webAsyncTask")
     public WebAsyncTask<String> webAsyncTask() {
       return new WebAsyncTask<>(() -> {
-        mockTracer.buildSpan("foo").startManual().finish();
+        mockTracer.buildSpan("foo").start().finish();
         return "webAsyncTask";
       });
     }
@@ -60,7 +60,7 @@ public class WebAsyncTaskTest {
     @RequestMapping("/callable")
     public Callable<String> callable() {
       return () -> {
-        mockTracer.buildSpan("foo").startManual().finish();
+        mockTracer.buildSpan("foo").start().finish();
         return "callable";
       };
     }

--- a/instrument-starters/opentracing-spring-cloud-feign-starter/src/test/java/io/opentracing/contrib/spring/cloud/feign/FeignHystrixTest.java
+++ b/instrument-starters/opentracing-spring-cloud-feign-starter/src/test/java/io/opentracing/contrib/spring/cloud/feign/FeignHystrixTest.java
@@ -42,8 +42,8 @@ public class FeignHystrixTest extends FeignTest {
   @Test
   public void testParentSpanRequest() {
     // create parent span to verify that Hystrix is instrumented and it propagates spans to callables
-    MockSpan parentSpan = mockTracer.buildSpan("parent").startManual();
-    try (Scope scope = mockTracer.scopeManager().activate(parentSpan, true)) {
+    MockSpan parentSpan = mockTracer.buildSpan("parent").start();
+    try (Scope scope = mockTracer.scopeManager().activate(parentSpan)) {
       feignInterface.hello();
       await().until(() -> mockTracer.finishedSpans().size() == 1);
       List<MockSpan> mockSpans = mockTracer.finishedSpans();

--- a/instrument-starters/opentracing-spring-cloud-hystrix-starter/src/test/java/io/opentracing/contrib/spring/cloud/hystrix/TracedHystrixCommandTest.java
+++ b/instrument-starters/opentracing-spring-cloud-hystrix-starter/src/test/java/io/opentracing/contrib/spring/cloud/hystrix/TracedHystrixCommandTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2018 The OpenTracing Authors
+ * Copyright 2017-2019 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -99,11 +99,12 @@ public class TracedHystrixCommandTest {
 
   @Test
   public void testWithoutCircuitBreaker() throws Exception {
-
-    try (Scope scope = mockTracer.buildSpan("test_without_circuit_breaker")
-        .startActive(true)) {
+    MockSpan span = mockTracer.buildSpan("test_without_circuit_breaker").start();
+    try (Scope scope = mockTracer.activateSpan(span)) {
       String response = greetingService.sayHello();
       assertThat(response).isNotNull();
+    } finally {
+      span.finish();
     }
 
     /**
@@ -125,10 +126,12 @@ public class TracedHystrixCommandTest {
 
   @Test
   public void testWithCircuitBreaker() {
-    try (Scope scope = mockTracer.buildSpan("test_with_circuit_breaker")
-        .startActive(true)) {
+    MockSpan span = mockTracer.buildSpan("test_with_circuit_breaker").start();
+    try (Scope scope = mockTracer.activateSpan(span)) {
       String response = greetingService.alwaysFail();
       assertThat(response).isNotNull();
+    } finally {
+      span.finish();
     }
 
     /**
@@ -155,8 +158,8 @@ public class TracedHystrixCommandTest {
     String groupKey = "test_hystrix";
     String commandKey = "hystrix_trace_command";
 
-    try (Scope scope = mockTracer.buildSpan("test_with_circuit_breaker")
-        .startActive(true)) {
+    MockSpan span = mockTracer.buildSpan("test_with_circuit_breaker").start();
+    try (Scope scope = mockTracer.activateSpan(span)) {
       com.netflix.hystrix.HystrixCommand.Setter setter = com.netflix.hystrix.HystrixCommand.Setter
           .withGroupKey(HystrixCommandGroupKey.Factory.asKey(groupKey))
           .andCommandKey(HystrixCommandKey.Factory.asKey(commandKey));
@@ -167,6 +170,8 @@ public class TracedHystrixCommandTest {
           return null;
         }
       }.execute();
+    } finally {
+      span.finish();
     }
 
     /**

--- a/instrument-starters/opentracing-spring-cloud-jdbc-starter/src/test/java/io/opentracing/contrib/spring/cloud/jdbc/jdbc/JdbcOnlyWithActiveTest.java
+++ b/instrument-starters/opentracing-spring-cloud-jdbc-starter/src/test/java/io/opentracing/contrib/spring/cloud/jdbc/jdbc/JdbcOnlyWithActiveTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2018 The OpenTracing Authors
+ * Copyright 2017-2019 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -11,7 +11,6 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-
 package io.opentracing.contrib.spring.cloud.jdbc.jdbc;
 
 import static org.junit.Assert.assertEquals;
@@ -65,9 +64,12 @@ public class JdbcOnlyWithActiveTest {
    */
   @Test
   public void spanJoinsActiveSpan() throws SQLException {
-    try (Scope ignored = tracer.buildSpan("parent").startActive(true)) {
+    MockSpan span = tracer.buildSpan("parent").start();
+    try (Scope ignored = tracer.activateSpan(span)) {
       assertTrue(dataSource.getConnection().prepareStatement("select 1").execute());
       assertEquals(1, tracer.finishedSpans().size());
+    } finally {
+      span.finish();
     }
 
     assertEquals(2, tracer.finishedSpans().size());

--- a/instrument-starters/opentracing-spring-cloud-mongo-starter/pom.xml
+++ b/instrument-starters/opentracing-spring-cloud-mongo-starter/pom.xml
@@ -45,6 +45,16 @@
         </exclusion>
       </exclusions>
     </dependency>
+    <dependency>
+      <groupId>io.opentracing.contrib</groupId>
+      <artifactId>opentracing-mongo-common</artifactId>
+      <exclusions>
+        <exclusion>
+          <artifactId>*</artifactId>
+          <groupId>*</groupId>
+        </exclusion>
+      </exclusions>
+    </dependency>
 
     <dependency>
       <groupId>org.springframework.boot</groupId>

--- a/instrument-starters/opentracing-spring-cloud-mongo-starter/src/main/java/io/opentracing/contrib/spring/cloud/mongo/MongoTracingAutoConfiguration.java
+++ b/instrument-starters/opentracing-spring-cloud-mongo-starter/src/main/java/io/opentracing/contrib/spring/cloud/mongo/MongoTracingAutoConfiguration.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2018 The OpenTracing Authors
+ * Copyright 2017-2019 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -17,6 +17,9 @@ import com.mongodb.MongoClient;
 import com.mongodb.MongoClientOptions;
 import io.opentracing.Tracer;
 import io.opentracing.contrib.mongo.TracingMongoClient;
+import io.opentracing.contrib.mongo.common.TracingCommandListener;
+import io.opentracing.contrib.mongo.common.TracingCommandListener.Builder;
+import io.opentracing.contrib.mongo.common.providers.PrefixSpanNameProvider;
 import io.opentracing.contrib.spring.tracer.configuration.TracerAutoConfiguration;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -52,6 +55,8 @@ public class MongoTracingAutoConfiguration extends MongoAutoConfiguration {
   @Override
   public MongoClient mongo() {
     MongoClient mongo = super.mongo();
-    return new TracingMongoClient(tracer, mongo.getAllAddress(), mongo.getCredentialsList(), mongo.getMongoClientOptions());
+    TracingCommandListener commandListener = new Builder(tracer)
+        .build();
+    return new TracingMongoClient(commandListener, mongo.getAllAddress(), mongo.getCredentialsList(), mongo.getMongoClientOptions());
   }
 }

--- a/instrument-starters/opentracing-spring-cloud-mongo-starter/src/test/java/io/opentracing/contrib/spring/cloud/mongo/MongoTracingTest.java
+++ b/instrument-starters/opentracing-spring-cloud-mongo-starter/src/test/java/io/opentracing/contrib/spring/cloud/mongo/MongoTracingTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2018 The OpenTracing Authors
+ * Copyright 2017-2019 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -94,9 +94,12 @@ public class MongoTracingTest {
    */
   @Test
   public void spanJoinsActiveSpan() {
-    try (Scope ignored = tracer.buildSpan("parent").startActive(true)) {
+    MockSpan span = tracer.buildSpan("parent").start();
+    try (Scope ignored = tracer.activateSpan(span)) {
       assertEquals("Ok", this.mongoTemplate.executeCommand("{ buildInfo: 1 }").getDouble("ok"), 1.0, 0);
       assertEquals(1, tracer.finishedSpans().size());
+    } finally {
+      span.finish();
     }
 
     assertEquals(2, tracer.finishedSpans().size());
@@ -128,9 +131,13 @@ public class MongoTracingTest {
     ExecutorService service = Executors.newFixedThreadPool(10);
     IntStream.rangeClosed(1, 150).parallel().forEach(i -> service.submit(() -> {
       // each iteration is like a request
-      try (Scope parent = tracer.buildSpan("parent_" + i).startActive(true)) {
-        parent.span().setTag("iteration", i);
+      MockSpan parentSpan = tracer.buildSpan("parent_" + i)
+          .withTag("iteration", i)
+          .start();
+      try (Scope scope = tracer.activateSpan(parentSpan)) {
         this.mongoTemplate.executeCommand("{ buildInfo : " + i + " }");
+      } finally {
+        parentSpan.finish();
       }
     }));
 

--- a/instrument-starters/opentracing-spring-cloud-redis-starter/pom.xml
+++ b/instrument-starters/opentracing-spring-cloud-redis-starter/pom.xml
@@ -36,7 +36,18 @@
     </dependency>
     <dependency>
       <groupId>io.opentracing.contrib</groupId>
-      <artifactId>opentracing-redis-spring</artifactId>
+      <artifactId>opentracing-redis-spring-data2</artifactId>
+      <version>${version.io.opentracing.contrib-opentracing-spring-redis}</version>
+      <exclusions>
+        <exclusion>
+          <artifactId>*</artifactId>
+          <groupId>*</groupId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>io.opentracing.contrib</groupId>
+      <artifactId>opentracing-redis-common</artifactId>
       <version>${version.io.opentracing.contrib-opentracing-spring-redis}</version>
       <exclusions>
         <exclusion>

--- a/instrument-starters/opentracing-spring-cloud-redis-starter/src/main/java/io/opentracing/contrib/spring/cloud/redis/RedisAspect.java
+++ b/instrument-starters/opentracing-spring-cloud-redis-starter/src/main/java/io/opentracing/contrib/spring/cloud/redis/RedisAspect.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2018 The OpenTracing Authors
+ * Copyright 2017-2019 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -13,8 +13,8 @@
  */
 package io.opentracing.contrib.spring.cloud.redis;
 
-import io.opentracing.contrib.redis.spring.connection.TracingRedisClusterConnection;
-import io.opentracing.contrib.redis.spring.connection.TracingRedisConnection;
+import io.opentracing.contrib.redis.spring.data2.connection.TracingRedisClusterConnection;
+import io.opentracing.contrib.redis.spring.data2.connection.TracingRedisConnection;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;

--- a/instrument-starters/opentracing-spring-cloud-websocket-starter/src/test/java/io/opentracing/contrib/spring/cloud/websocket/GreetingController.java
+++ b/instrument-starters/opentracing-spring-cloud-websocket-starter/src/test/java/io/opentracing/contrib/spring/cloud/websocket/GreetingController.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2018 The OpenTracing Authors
+ * Copyright 2017-2019 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -30,7 +30,7 @@ public class GreetingController {
   @MessageMapping("/hello")
   @SendTo("/topic/greetings")
   public Greeting greeting(HelloMessage message) throws Exception {
-    tracer.buildSpan(DOING_WORK).startActive(true).close();
+    tracer.buildSpan(DOING_WORK).start().finish();
     return new Greeting("Hello, " + message.getName() + "!");
   }
 

--- a/instrument-starters/opentracing-spring-cloud-websocket-starter/src/test/java/io/opentracing/contrib/spring/cloud/websocket/TracingChannelInterceptorTest.java
+++ b/instrument-starters/opentracing-spring-cloud-websocket-starter/src/test/java/io/opentracing/contrib/spring/cloud/websocket/TracingChannelInterceptorTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2018 The OpenTracing Authors
+ * Copyright 2017-2019 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -38,7 +38,7 @@ public class TracingChannelInterceptorTest {
         .setHeader(TracingChannelInterceptor.SIMP_MESSAGE_TYPE, SimpMessageType.MESSAGE)
         .setHeader(TracingChannelInterceptor.SIMP_DESTINATION, TEST_DESTINATION);
 
-    MockSpan parentSpan = mockTracer.buildSpan("parent").startManual();
+    MockSpan parentSpan = mockTracer.buildSpan("parent").start();
     mockTracer.inject(parentSpan.context(), Format.Builtin.TEXT_MAP,
         new TextMapInjectAdapter(messageBuilder));
 
@@ -65,15 +65,15 @@ public class TracingChannelInterceptorTest {
         .setHeader(TracingChannelInterceptor.SIMP_MESSAGE_TYPE, SimpMessageType.MESSAGE)
         .setHeader(TracingChannelInterceptor.SIMP_DESTINATION, TEST_DESTINATION);
 
-    MockSpan parentSpan = mockTracer.buildSpan("parent").startManual();
-    Scope parentScope = mockTracer.scopeManager().activate(parentSpan, true);
+    MockSpan parentSpan = mockTracer.buildSpan("parent").start();
 
     TracingChannelInterceptor interceptor = new TracingChannelInterceptor(mockTracer,
         Tags.SPAN_KIND_CLIENT);
 
+    Scope parentScope = mockTracer.scopeManager().activate(parentSpan);
     Message<?> processed = interceptor.preSend(messageBuilder.build(), null);
-
     parentScope.close();
+    parentSpan.finish();
 
     // Verify span cached with message is child of the active parentSpan
     assertTrue(processed.getHeaders().containsKey(TracingChannelInterceptor.OPENTRACING_SPAN));

--- a/instrument-starters/opentracing-spring-cloud-zuul-starter/src/main/java/io/opentracing/contrib/spring/cloud/zuul/TracePostZuulFilter.java
+++ b/instrument-starters/opentracing-spring-cloud-zuul-starter/src/main/java/io/opentracing/contrib/spring/cloud/zuul/TracePostZuulFilter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2018 The OpenTracing Authors
+ * Copyright 2017-2019 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -12,6 +12,8 @@
  * the License.
  */
 package io.opentracing.contrib.spring.cloud.zuul;
+
+import static org.springframework.cloud.netflix.zuul.filters.support.FilterConstants.POST_TYPE;
 
 import com.netflix.zuul.ZuulFilter;
 import com.netflix.zuul.context.RequestContext;
@@ -26,8 +28,7 @@ public class TracePostZuulFilter extends ZuulFilter {
 
   @Override
   public String filterType() {
-    // TODO: replace with org.springframework.cloud.netflix.zuul.filters.support.FilterConstants.POST_TYPE
-    return "post";
+    return POST_TYPE;
   }
 
   @Override

--- a/instrument-starters/opentracing-spring-cloud-zuul-starter/src/main/java/io/opentracing/contrib/spring/cloud/zuul/TracePreZuulFilter.java
+++ b/instrument-starters/opentracing-spring-cloud-zuul-starter/src/main/java/io/opentracing/contrib/spring/cloud/zuul/TracePreZuulFilter.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2018 The OpenTracing Authors
+ * Copyright 2017-2019 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -13,12 +13,14 @@
  */
 package io.opentracing.contrib.spring.cloud.zuul;
 
+import static org.springframework.cloud.netflix.zuul.filters.support.FilterConstants.PRE_TYPE;
+
 import com.netflix.zuul.ZuulFilter;
 import com.netflix.zuul.context.RequestContext;
 import io.opentracing.Span;
 import io.opentracing.Tracer;
 import io.opentracing.propagation.Format;
-import io.opentracing.propagation.TextMapInjectAdapter;
+import io.opentracing.propagation.TextMapAdapter;
 import io.opentracing.tag.Tags;
 
 class TracePreZuulFilter extends ZuulFilter {
@@ -34,8 +36,7 @@ class TracePreZuulFilter extends ZuulFilter {
 
   @Override
   public String filterType() {
-    // TODO: replace with org.springframework.cloud.netflix.zuul.filters.support.FilterConstants.PRE_TYPE
-    return "pre";
+    return PRE_TYPE;
   }
 
   @Override
@@ -58,7 +59,7 @@ class TracePreZuulFilter extends ZuulFilter {
         .start();
 
     tracer.inject(span.context(), Format.Builtin.HTTP_HEADERS,
-        new TextMapInjectAdapter(ctx.getZuulRequestHeaders()));
+        new TextMapAdapter(ctx.getZuulRequestHeaders()));
 
     ctx.set(CONTEXT_SPAN_KEY, span);
 

--- a/pom.xml
+++ b/pom.xml
@@ -71,20 +71,20 @@
     <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
     <main.basedir>${project.basedir}</main.basedir>
 
-    <version.io.opentracing>0.31.0</version.io.opentracing>
+    <version.io.opentracing>0.32.0</version.io.opentracing>
     <version.io.opentracing.contrib-opentracing-spring-tracer-configuration-starter>0.1.0</version.io.opentracing.contrib-opentracing-spring-tracer-configuration-starter>
-    <version.io.opentracing.contrib-opentracing-spring-web>1.1.2</version.io.opentracing.contrib-opentracing-spring-web>
-    <version.io.opentracing.contrib-opentracing-spring-jms>0.0.10</version.io.opentracing.contrib-opentracing-spring-jms>
-    <version.io.opentracing.contrib-opentracing-spring-messaging>0.1.1</version.io.opentracing.contrib-opentracing-spring-messaging>
-    <version.io.opentracing.contrib-opentracing-spring-rabbitmq>1.0.1</version.io.opentracing.contrib-opentracing-spring-rabbitmq>
-    <version.io.opentracing.contrib-java-jdbc>0.0.12</version.io.opentracing.contrib-java-jdbc>
-    <version.io.opentracing.contrib-opentracing-spring-redis>0.0.10</version.io.opentracing.contrib-opentracing-spring-redis>
-    <version.io.opentracing.contrib-java-concurrent>0.2.1</version.io.opentracing.contrib-java-concurrent>
-    <version.io.opentracing.contrib-opentracing-reactor>0.0.2</version.io.opentracing.contrib-opentracing-reactor>
-    <version.io.opentracing.contrib-opentracing-rxjava-1>0.0.9</version.io.opentracing.contrib-opentracing-rxjava-1>
-    <version.io.opentracing.contrib-opentracing-spring-mongo>0.0.6</version.io.opentracing.contrib-opentracing-spring-mongo>
-    <version.io.github.openfeign-feign-okhttp>9.5.0</version.io.github.openfeign-feign-okhttp>
-    <version.io.github.openfeign.opentracing>0.1.0</version.io.github.openfeign.opentracing>
+    <version.io.opentracing.contrib-opentracing-spring-web>2.1.0</version.io.opentracing.contrib-opentracing-spring-web>
+    <version.io.opentracing.contrib-opentracing-spring-jms>0.1.0</version.io.opentracing.contrib-opentracing-spring-jms>
+    <version.io.opentracing.contrib-opentracing-spring-messaging>0.1.2</version.io.opentracing.contrib-opentracing-spring-messaging>
+    <version.io.opentracing.contrib-opentracing-spring-rabbitmq>2.0.0</version.io.opentracing.contrib-opentracing-spring-rabbitmq>
+    <version.io.opentracing.contrib-java-jdbc>0.1.1</version.io.opentracing.contrib-java-jdbc>
+    <version.io.opentracing.contrib-opentracing-spring-redis>0.1.2</version.io.opentracing.contrib-opentracing-spring-redis>
+    <version.io.opentracing.contrib-java-concurrent>0.3.0</version.io.opentracing.contrib-java-concurrent>
+    <version.io.opentracing.contrib-opentracing-reactor>0.1.0</version.io.opentracing.contrib-opentracing-reactor>
+    <version.io.opentracing.contrib-opentracing-rxjava-1>0.1.0</version.io.opentracing.contrib-opentracing-rxjava-1>
+    <version.io.opentracing.contrib-opentracing-spring-mongo>0.1.2</version.io.opentracing.contrib-opentracing-spring-mongo>
+    <version.io.github.openfeign-feign-okhttp>10.2.0</version.io.github.openfeign-feign-okhttp>
+    <version.io.github.openfeign.opentracing>0.3.0</version.io.github.openfeign.opentracing>
     <!-- spring-boot-starter-parent is a module of spring-boot-dependencies
         https://github.com/spring-projects/spring-boot/blob/master/spring-boot-starters/spring-boot-starter-parent/pom.xml -->
     <version.org.springframework.boot>2.1.4.RELEASE</version.org.springframework.boot>
@@ -243,6 +243,11 @@
       <dependency>
         <groupId>io.opentracing.contrib</groupId>
         <artifactId>opentracing-mongo-driver</artifactId>
+        <version>${version.io.opentracing.contrib-opentracing-spring-mongo}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.opentracing.contrib</groupId>
+        <artifactId>opentracing-mongo-common</artifactId>
         <version>${version.io.opentracing.contrib-opentracing-spring-mongo}</version>
       </dependency>
 


### PR DESCRIPTION
WIP: first we need to update all instrumentation dependencies.

Depends on:

- [x] web https://github.com/opentracing-contrib/java-spring-web/pull/102
- [x] messaging https://github.com/opentracing-contrib/java-spring-messaging/issues/27
- [x] rabbitmq https://github.com/opentracing-contrib/java-spring-rabbitmq/issues/28
- [x] reactor https://github.com/opentracing-contrib/java-reactor/issues/5
