### PR TITLE
Bump some dependency versions which are compatible with OT 0.31.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -73,13 +73,13 @@
 
     <version.io.opentracing>0.31.0</version.io.opentracing>
     <version.io.opentracing.contrib-opentracing-spring-tracer-configuration-starter>0.1.0</version.io.opentracing.contrib-opentracing-spring-tracer-configuration-starter>
-    <version.io.opentracing.contrib-opentracing-spring-web>1.1.1</version.io.opentracing.contrib-opentracing-spring-web>
+    <version.io.opentracing.contrib-opentracing-spring-web>1.1.2</version.io.opentracing.contrib-opentracing-spring-web>
     <version.io.opentracing.contrib-opentracing-spring-jms>0.0.10</version.io.opentracing.contrib-opentracing-spring-jms>
-    <version.io.opentracing.contrib-opentracing-spring-messaging>0.0.5</version.io.opentracing.contrib-opentracing-spring-messaging>
+    <version.io.opentracing.contrib-opentracing-spring-messaging>0.1.1</version.io.opentracing.contrib-opentracing-spring-messaging>
     <version.io.opentracing.contrib-opentracing-spring-rabbitmq>1.0.1</version.io.opentracing.contrib-opentracing-spring-rabbitmq>
     <version.io.opentracing.contrib-java-jdbc>0.0.12</version.io.opentracing.contrib-java-jdbc>
     <version.io.opentracing.contrib-opentracing-spring-redis>0.0.10</version.io.opentracing.contrib-opentracing-spring-redis>
-    <version.io.opentracing.contrib-java-concurrent>0.2.0</version.io.opentracing.contrib-java-concurrent>
+    <version.io.opentracing.contrib-java-concurrent>0.2.1</version.io.opentracing.contrib-java-concurrent>
     <version.io.opentracing.contrib-opentracing-reactor>0.0.2</version.io.opentracing.contrib-opentracing-reactor>
     <version.io.opentracing.contrib-opentracing-rxjava-1>0.0.9</version.io.opentracing.contrib-opentracing-rxjava-1>
     <version.io.opentracing.contrib-opentracing-spring-mongo>0.0.6</version.io.opentracing.contrib-opentracing-spring-mongo>
@@ -93,7 +93,7 @@
     <version.de.flapdoodle-embed.mongo>2.0.3</version.de.flapdoodle-embed.mongo>
     <version.cz.jirutka.spring-embedmongo-spring>1.3.1</version.cz.jirutka.spring-embedmongo-spring>
     <version.org.slf4j-log4j-over-slf4j>1.7.25</version.org.slf4j-log4j-over-slf4j>
-    <version.reactor-core>3.2.3.RELEASE</version.reactor-core>
+    <version.reactor-core>3.2.8.RELEASE</version.reactor-core>
 
     <version.javax.jms>1.1-rev-1</version.javax.jms>
 


### PR DESCRIPTION
Resolves #218 

This PR is related to issue #218 to upgrade to latest dependencies which are compatible with 0.31.0 before your eventual release which will be based on 0.32.0.