### PR TITLE
#236 Fix websocket TracingChannelInterceptor throwing UnsupportedOperationException

### DIFF
--- a/instrument-starters/opentracing-spring-cloud-websocket-starter/src/main/java/io/opentracing/contrib/spring/cloud/websocket/TracingChannelInterceptor.java
+++ b/instrument-starters/opentracing-spring-cloud-websocket-starter/src/main/java/io/opentracing/contrib/spring/cloud/websocket/TracingChannelInterceptor.java
@@ -120,7 +120,6 @@ public class TracingChannelInterceptor extends ChannelInterceptorAdapter impleme
         SimpMessageType.MESSAGE.equals(message.getHeaders().get(SIMP_MESSAGE_TYPE))) {
       message.getHeaders().get(OPENTRACING_SCOPE, Scope.class).close();
       message.getHeaders().get(OPENTRACING_SPAN, Span.class).finish();
-      message.getHeaders().remove(OPENTRACING_SCOPE);
     }
   }
 


### PR DESCRIPTION
* since the headers are immutable, cannot call remove, thus removed the line
* add test

Resolves  https://github.com/opentracing-contrib/java-spring-cloud/issues/236