### PR TITLE
Create a TracingMongoClient bean only when one already exists or is created by MongoAutoConfiguration

### DIFF
--- a/instrument-starters/opentracing-spring-cloud-mongo-starter/src/main/java/io/opentracing/contrib/spring/cloud/mongo/MongoTracingAutoConfiguration.java
+++ b/instrument-starters/opentracing-spring-cloud-mongo-starter/src/main/java/io/opentracing/contrib/spring/cloud/mongo/MongoTracingAutoConfiguration.java
@@ -39,7 +39,7 @@ public class MongoTracingAutoConfiguration {
   }
 
   @Bean
-  public TracingMongoClientPostProcessor tracingMongoClientPostProcessor() {
+  TracingMongoClientPostProcessor tracingMongoClientPostProcessor() {
     return new TracingMongoClientPostProcessor(tracer);
   }
 }

--- a/instrument-starters/opentracing-spring-cloud-mongo-starter/src/main/java/io/opentracing/contrib/spring/cloud/mongo/MongoTracingAutoConfiguration.java
+++ b/instrument-starters/opentracing-spring-cloud-mongo-starter/src/main/java/io/opentracing/contrib/spring/cloud/mongo/MongoTracingAutoConfiguration.java
@@ -13,14 +13,18 @@
  */
 package io.opentracing.contrib.spring.cloud.mongo;
 
+import com.mongodb.MongoClient;
 import io.opentracing.Tracer;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
 /**
  * @author Vivien Maleze
  */
 @Configuration
+@ConditionalOnBean({ Tracer.class, MongoClient.class })
 @ConditionalOnProperty(name = "opentracing.spring.cloud.mongo.enabled", havingValue = "true", matchIfMissing = true)
 public class MongoTracingAutoConfiguration {
 
@@ -30,4 +34,8 @@ public class MongoTracingAutoConfiguration {
     this.tracer = tracer;
   }
 
+  @Bean
+  public TracingMongoClientPostProcessor tracingMongoClientPostProcessor() {
+    return new TracingMongoClientPostProcessor(tracer);
+  }
 }

--- a/instrument-starters/opentracing-spring-cloud-mongo-starter/src/main/java/io/opentracing/contrib/spring/cloud/mongo/MongoTracingAutoConfiguration.java
+++ b/instrument-starters/opentracing-spring-cloud-mongo-starter/src/main/java/io/opentracing/contrib/spring/cloud/mongo/MongoTracingAutoConfiguration.java
@@ -13,50 +13,21 @@
  */
 package io.opentracing.contrib.spring.cloud.mongo;
 
-import com.mongodb.MongoClient;
-import com.mongodb.MongoClientOptions;
 import io.opentracing.Tracer;
-import io.opentracing.contrib.mongo.TracingMongoClient;
-import io.opentracing.contrib.mongo.common.TracingCommandListener;
-import io.opentracing.contrib.mongo.common.TracingCommandListener.Builder;
-import io.opentracing.contrib.mongo.common.providers.PrefixSpanNameProvider;
-import io.opentracing.contrib.spring.tracer.configuration.TracerAutoConfiguration;
-import org.springframework.beans.factory.ObjectProvider;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.autoconfigure.AutoConfigureAfter;
-import org.springframework.boot.autoconfigure.AutoConfigureBefore;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
-import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
-import org.springframework.boot.autoconfigure.mongo.MongoAutoConfiguration;
-import org.springframework.boot.autoconfigure.mongo.MongoProperties;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.core.env.Environment;
 
 /**
  * @author Vivien Maleze
  */
 @Configuration
-@AutoConfigureBefore(MongoAutoConfiguration.class)
-@ConditionalOnClass(MongoClient.class)
-@ConditionalOnBean(Tracer.class)
-@AutoConfigureAfter(TracerAutoConfiguration.class)
 @ConditionalOnProperty(name = "opentracing.spring.cloud.mongo.enabled", havingValue = "true", matchIfMissing = true)
-public class MongoTracingAutoConfiguration extends MongoAutoConfiguration {
+public class MongoTracingAutoConfiguration {
 
-  private Tracer tracer;
+  private final Tracer tracer;
 
-  public MongoTracingAutoConfiguration(@Autowired(required = false) MongoProperties properties,
-      ObjectProvider<MongoClientOptions> options, Environment environment, Tracer tracer) {
-    super(properties, options, environment);
+  public MongoTracingAutoConfiguration(final Tracer tracer) {
     this.tracer = tracer;
   }
 
-  @Override
-  public MongoClient mongo() {
-    MongoClient mongo = super.mongo();
-    TracingCommandListener commandListener = new Builder(tracer)
-        .build();
-    return new TracingMongoClient(commandListener, mongo.getAllAddress(), mongo.getCredentialsList(), mongo.getMongoClientOptions());
-  }
 }

--- a/instrument-starters/opentracing-spring-cloud-mongo-starter/src/main/java/io/opentracing/contrib/spring/cloud/mongo/MongoTracingAutoConfiguration.java
+++ b/instrument-starters/opentracing-spring-cloud-mongo-starter/src/main/java/io/opentracing/contrib/spring/cloud/mongo/MongoTracingAutoConfiguration.java
@@ -15,8 +15,11 @@ package io.opentracing.contrib.spring.cloud.mongo;
 
 import com.mongodb.MongoClient;
 import io.opentracing.Tracer;
+import io.opentracing.contrib.spring.tracer.configuration.TracerAutoConfiguration;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.mongo.MongoAutoConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 
@@ -24,6 +27,7 @@ import org.springframework.context.annotation.Configuration;
  * @author Vivien Maleze
  */
 @Configuration
+@AutoConfigureAfter({ TracerAutoConfiguration.class, MongoAutoConfiguration.class })
 @ConditionalOnBean({ Tracer.class, MongoClient.class })
 @ConditionalOnProperty(name = "opentracing.spring.cloud.mongo.enabled", havingValue = "true", matchIfMissing = true)
 public class MongoTracingAutoConfiguration {

--- a/instrument-starters/opentracing-spring-cloud-mongo-starter/src/main/java/io/opentracing/contrib/spring/cloud/mongo/TracingMongoClientPostProcessor.java
+++ b/instrument-starters/opentracing-spring-cloud-mongo-starter/src/main/java/io/opentracing/contrib/spring/cloud/mongo/TracingMongoClientPostProcessor.java
@@ -1,0 +1,32 @@
+package io.opentracing.contrib.spring.cloud.mongo;
+
+import com.mongodb.MongoClient;
+import io.opentracing.Tracer;
+import io.opentracing.contrib.mongo.TracingMongoClient;
+import io.opentracing.contrib.mongo.common.TracingCommandListener;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+
+public class TracingMongoClientPostProcessor implements BeanPostProcessor {
+
+  private final Tracer tracer;
+
+  TracingMongoClientPostProcessor(Tracer tracer) {
+    this.tracer = tracer;
+  }
+
+  @Override
+  public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
+
+    if (bean instanceof MongoClient) {
+      final MongoClient client = (MongoClient) bean;
+
+      final TracingCommandListener commandListener = new TracingCommandListener.Builder(tracer)
+          .build();
+
+      return new TracingMongoClient(commandListener, client.getAllAddress(), client.getCredentialsList(), client.getMongoClientOptions());
+    }
+
+    return bean;
+  }
+}

--- a/instrument-starters/opentracing-spring-cloud-mongo-starter/src/main/java/io/opentracing/contrib/spring/cloud/mongo/TracingMongoClientPostProcessor.java
+++ b/instrument-starters/opentracing-spring-cloud-mongo-starter/src/main/java/io/opentracing/contrib/spring/cloud/mongo/TracingMongoClientPostProcessor.java
@@ -20,7 +20,7 @@ import io.opentracing.contrib.mongo.common.TracingCommandListener;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.config.BeanPostProcessor;
 
-public class TracingMongoClientPostProcessor implements BeanPostProcessor {
+class TracingMongoClientPostProcessor implements BeanPostProcessor {
 
   private final Tracer tracer;
 

--- a/instrument-starters/opentracing-spring-cloud-mongo-starter/src/main/java/io/opentracing/contrib/spring/cloud/mongo/TracingMongoClientPostProcessor.java
+++ b/instrument-starters/opentracing-spring-cloud-mongo-starter/src/main/java/io/opentracing/contrib/spring/cloud/mongo/TracingMongoClientPostProcessor.java
@@ -1,3 +1,16 @@
+/**
+ * Copyright 2017-2019 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package io.opentracing.contrib.spring.cloud.mongo;
 
 import com.mongodb.MongoClient;

--- a/instrument-starters/opentracing-spring-cloud-mongo-starter/src/main/java/io/opentracing/contrib/spring/cloud/mongo/TracingMongoClientPostProcessor.java
+++ b/instrument-starters/opentracing-spring-cloud-mongo-starter/src/main/java/io/opentracing/contrib/spring/cloud/mongo/TracingMongoClientPostProcessor.java
@@ -31,7 +31,7 @@ public class TracingMongoClientPostProcessor implements BeanPostProcessor {
   @Override
   public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
 
-    if (bean instanceof MongoClient) {
+    if (bean instanceof MongoClient && !(bean instanceof TracingMongoClient)) {
       final MongoClient client = (MongoClient) bean;
 
       final TracingCommandListener commandListener = new TracingCommandListener.Builder(tracer)

--- a/instrument-starters/opentracing-spring-cloud-mongo-starter/src/test/java/io/opentracing/contrib/spring/cloud/mongo/MongoTracingAutoConfigurationTest.java
+++ b/instrument-starters/opentracing-spring-cloud-mongo-starter/src/test/java/io/opentracing/contrib/spring/cloud/mongo/MongoTracingAutoConfigurationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2018 The OpenTracing Authors
+ * Copyright 2017-2019 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -13,6 +13,8 @@
  */
 package io.opentracing.contrib.spring.cloud.mongo;
 
+import static org.mockito.Mockito.mock;
+
 import com.mongodb.MongoClient;
 import com.mongodb.MongoClientURI;
 import io.opentracing.Tracer;
@@ -25,8 +27,6 @@ import org.springframework.boot.context.annotation.UserConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-
-import static org.mockito.Mockito.mock;
 
 /**
  * @author Vivien Maleze

--- a/instrument-starters/opentracing-spring-cloud-mongo-starter/src/test/java/io/opentracing/contrib/spring/cloud/mongo/MongoTracingAutoConfigurationTest.java
+++ b/instrument-starters/opentracing-spring-cloud-mongo-starter/src/test/java/io/opentracing/contrib/spring/cloud/mongo/MongoTracingAutoConfigurationTest.java
@@ -14,7 +14,6 @@
 package io.opentracing.contrib.spring.cloud.mongo;
 
 import com.mongodb.MongoClient;
-import com.mongodb.MongoClientOptions;
 import com.mongodb.MongoClientURI;
 import io.opentracing.Tracer;
 import io.opentracing.contrib.spring.tracer.configuration.TracerAutoConfiguration;
@@ -97,7 +96,7 @@ public class MongoTracingAutoConfigurationTest {
 
     @Bean
     public MongoClient client() {
-      return new MongoClient(new MongoClientURI("mongodb://localhost/test", MongoClientOptions.builder()));
+      return new MongoClient(new MongoClientURI("mongodb://localhost/test"));
     }
   }
 }

--- a/instrument-starters/opentracing-spring-cloud-mongo-starter/src/test/java/io/opentracing/contrib/spring/cloud/mongo/MongoTracingAutoConfigurationTest.java
+++ b/instrument-starters/opentracing-spring-cloud-mongo-starter/src/test/java/io/opentracing/contrib/spring/cloud/mongo/MongoTracingAutoConfigurationTest.java
@@ -21,6 +21,7 @@ import io.opentracing.contrib.spring.tracer.configuration.TracerAutoConfiguratio
 import org.assertj.core.api.Assertions;
 import org.junit.Test;
 import org.springframework.boot.autoconfigure.AutoConfigurations;
+import org.springframework.boot.autoconfigure.mongo.MongoAutoConfiguration;
 import org.springframework.boot.context.annotation.UserConfigurations;
 import org.springframework.boot.test.context.runner.ApplicationContextRunner;
 import org.springframework.context.annotation.Bean;
@@ -37,7 +38,7 @@ public class MongoTracingAutoConfigurationTest {
   public void createsTracingPostProcessor() {
     final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
         .withConfiguration(UserConfigurations.of(TracerConfig.class, MongoConfig.class))
-        .withConfiguration(AutoConfigurations.of(TracerAutoConfiguration.class, MongoTracingAutoConfiguration.class));
+        .withConfiguration(AutoConfigurations.of(MongoTracingAutoConfiguration.class));
 
     contextRunner.run(context -> Assertions.assertThat(context).hasSingleBean(TracingMongoClientPostProcessor.class));
   }
@@ -46,7 +47,7 @@ public class MongoTracingAutoConfigurationTest {
   public void doesNotCreateTracingPostProcessorWhenNoTracer() {
     final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
         .withConfiguration(UserConfigurations.of(MongoConfig.class))
-        .withConfiguration(AutoConfigurations.of(TracerAutoConfiguration.class, MongoTracingAutoConfiguration.class));
+        .withConfiguration(AutoConfigurations.of(MongoTracingAutoConfiguration.class));
 
     contextRunner.run(context -> Assertions.assertThat(context).doesNotHaveBean(TracingMongoClientPostProcessor.class));
   }
@@ -55,7 +56,7 @@ public class MongoTracingAutoConfigurationTest {
   public void doesNotCreateTracingPostProcessorWhenNoMongoClient() {
     final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
         .withConfiguration(UserConfigurations.of(TracerConfig.class))
-        .withConfiguration(AutoConfigurations.of(TracerAutoConfiguration.class, MongoTracingAutoConfiguration.class));
+        .withConfiguration(AutoConfigurations.of(MongoTracingAutoConfiguration.class));
 
     contextRunner.run(context -> Assertions.assertThat(context).doesNotHaveBean(TracingMongoClientPostProcessor.class));
   }
@@ -65,9 +66,21 @@ public class MongoTracingAutoConfigurationTest {
     final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
         .withPropertyValues("opentracing.spring.cloud.mongo.enabled=false")
         .withConfiguration(UserConfigurations.of(TracerConfig.class, MongoConfig.class))
-        .withConfiguration(AutoConfigurations.of(TracerAutoConfiguration.class, MongoTracingAutoConfiguration.class));
+        .withConfiguration(AutoConfigurations.of(MongoTracingAutoConfiguration.class));
 
     contextRunner.run(context -> Assertions.assertThat(context).doesNotHaveBean(TracingMongoClientPostProcessor.class));
+  }
+
+  @Test
+  public void createsTracingPostProcessorWhenAutoConfigured() {
+    final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+        .withConfiguration(AutoConfigurations.of(
+            MongoTracingAutoConfiguration.class,
+            TracerAutoConfiguration.class,
+            MongoAutoConfiguration.class
+        ));
+
+    contextRunner.run(context -> Assertions.assertThat(context).hasSingleBean(TracingMongoClientPostProcessor.class));
   }
 
   @Configuration

--- a/instrument-starters/opentracing-spring-cloud-mongo-starter/src/test/java/io/opentracing/contrib/spring/cloud/mongo/MongoTracingAutoConfigurationTest.java
+++ b/instrument-starters/opentracing-spring-cloud-mongo-starter/src/test/java/io/opentracing/contrib/spring/cloud/mongo/MongoTracingAutoConfigurationTest.java
@@ -13,42 +13,16 @@
  */
 package io.opentracing.contrib.spring.cloud.mongo;
 
-import static org.hamcrest.Matchers.is;
-import static org.junit.Assert.assertNotNull;
-import static org.junit.Assert.assertThat;
-import static org.mockito.Mockito.mock;
-
-import com.mongodb.MongoClient;
 import io.opentracing.Tracer;
-import org.junit.Test;
-import org.springframework.boot.test.util.TestPropertyValues;
-import org.springframework.context.annotation.AnnotationConfigApplicationContext;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+
+import static org.mockito.Mockito.mock;
 
 /**
  * @author Vivien Maleze
  */
 public class MongoTracingAutoConfigurationTest {
-
-  @Test
-  public void loadMongoTracingByDefault() {
-    AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
-    context.register(TracerConfig.class, MongoTracingAutoConfiguration.class);
-    context.refresh();
-    MongoClient mongoClient = context.getBean(MongoClient.class);
-    assertNotNull(mongoClient);
-  }
-
-  @Test
-  public void disableMongoTracing() {
-    AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
-    context.register(TracerConfig.class, MongoTracingAutoConfiguration.class);
-    TestPropertyValues.of("opentracing.spring.cloud.mongo.enabled:false").applyTo(context);
-    context.refresh();
-    String[] tracingMongoClientBeans = context.getBeanNamesForType(MongoClient.class);
-    assertThat(tracingMongoClientBeans.length, is(0));
-  }
 
   @Configuration
   static class TracerConfig {
@@ -58,4 +32,5 @@ public class MongoTracingAutoConfigurationTest {
       return mock(Tracer.class);
     }
   }
+
 }

--- a/instrument-starters/opentracing-spring-cloud-mongo-starter/src/test/java/io/opentracing/contrib/spring/cloud/mongo/MongoTracingAutoConfigurationTest.java
+++ b/instrument-starters/opentracing-spring-cloud-mongo-starter/src/test/java/io/opentracing/contrib/spring/cloud/mongo/MongoTracingAutoConfigurationTest.java
@@ -35,7 +35,6 @@ public class MongoTracingAutoConfigurationTest {
 
   @Test
   public void createsTracingPostProcessor() {
-
     final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
         .withConfiguration(UserConfigurations.of(TracerConfig.class, MongoConfig.class))
         .withConfiguration(AutoConfigurations.of(TracerAutoConfiguration.class, MongoTracingAutoConfiguration.class));
@@ -56,6 +55,16 @@ public class MongoTracingAutoConfigurationTest {
   public void doesNotCreateTracingPostProcessorWhenNoMongoClient() {
     final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
         .withConfiguration(UserConfigurations.of(TracerConfig.class))
+        .withConfiguration(AutoConfigurations.of(TracerAutoConfiguration.class, MongoTracingAutoConfiguration.class));
+
+    contextRunner.run(context -> Assertions.assertThat(context).doesNotHaveBean(TracingMongoClientPostProcessor.class));
+  }
+
+  @Test
+  public void doesNotCreateTracingPostProcessorWhenDisabled() {
+    final ApplicationContextRunner contextRunner = new ApplicationContextRunner()
+        .withPropertyValues("opentracing.spring.cloud.mongo.enabled=false")
+        .withConfiguration(UserConfigurations.of(TracerConfig.class, MongoConfig.class))
         .withConfiguration(AutoConfigurations.of(TracerAutoConfiguration.class, MongoTracingAutoConfiguration.class));
 
     contextRunner.run(context -> Assertions.assertThat(context).doesNotHaveBean(TracingMongoClientPostProcessor.class));

--- a/instrument-starters/opentracing-spring-cloud-mongo-starter/src/test/java/io/opentracing/contrib/spring/cloud/mongo/TracingMongoClientPostProcessorTest.java
+++ b/instrument-starters/opentracing-spring-cloud-mongo-starter/src/test/java/io/opentracing/contrib/spring/cloud/mongo/TracingMongoClientPostProcessorTest.java
@@ -14,7 +14,6 @@
 package io.opentracing.contrib.spring.cloud.mongo;
 
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.mockito.Mockito.mock;
 
 import com.mongodb.MongoClient;
 import com.mongodb.MongoClientOptions;
@@ -29,6 +28,9 @@ public class TracingMongoClientPostProcessorTest {
 
   @Mock
   private Tracer tracer;
+
+  @Mock
+  private TracingMongoClient tracingClient;
 
   private TracingMongoClientPostProcessor processor;
 
@@ -60,10 +62,8 @@ public class TracingMongoClientPostProcessorTest {
   @Test
   public void testTracingMongoClientBeanNotWrapped() {
 
-    final TracingMongoClient tracingClientMock = mock(TracingMongoClient.class);
+    final Object actual = processor.postProcessAfterInitialization(tracingClient, "any-bean-name");
 
-    final Object actual = processor.postProcessAfterInitialization(tracingClientMock, "any-bean-name");
-
-    assertThat(actual).isSameAs(tracingClientMock);
+    assertThat(actual).isSameAs(tracingClient);
   }
 }

--- a/instrument-starters/opentracing-spring-cloud-mongo-starter/src/test/java/io/opentracing/contrib/spring/cloud/mongo/TracingMongoClientPostProcessorTest.java
+++ b/instrument-starters/opentracing-spring-cloud-mongo-starter/src/test/java/io/opentracing/contrib/spring/cloud/mongo/TracingMongoClientPostProcessorTest.java
@@ -1,4 +1,19 @@
+/**
+ * Copyright 2017-2019 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
 package io.opentracing.contrib.spring.cloud.mongo;
+
+import static org.assertj.core.api.Assertions.assertThat;
 
 import com.mongodb.MongoClient;
 import com.mongodb.MongoClientOptions;
@@ -8,8 +23,6 @@ import io.opentracing.contrib.mongo.TracingMongoClient;
 import org.junit.Before;
 import org.junit.Test;
 import org.mockito.Mock;
-
-import static org.assertj.core.api.Assertions.assertThat;
 
 public class TracingMongoClientPostProcessorTest {
 

--- a/instrument-starters/opentracing-spring-cloud-mongo-starter/src/test/java/io/opentracing/contrib/spring/cloud/mongo/TracingMongoClientPostProcessorTest.java
+++ b/instrument-starters/opentracing-spring-cloud-mongo-starter/src/test/java/io/opentracing/contrib/spring/cloud/mongo/TracingMongoClientPostProcessorTest.java
@@ -1,0 +1,45 @@
+package io.opentracing.contrib.spring.cloud.mongo;
+
+import com.mongodb.MongoClient;
+import com.mongodb.MongoClientOptions;
+import com.mongodb.MongoClientURI;
+import io.opentracing.Tracer;
+import io.opentracing.contrib.mongo.TracingMongoClient;
+import org.junit.Before;
+import org.junit.Test;
+import org.mockito.Mock;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class TracingMongoClientPostProcessorTest {
+
+  @Mock
+  private Tracer tracer;
+
+  private TracingMongoClientPostProcessor processor;
+
+  @Before
+  public void setup() {
+    processor = new TracingMongoClientPostProcessor(tracer);
+  }
+
+  @Test
+  public void testNonMongoClientBeansAreReturnedUnaltered() {
+
+    final Object expected = new Object();
+
+    final Object actual = processor.postProcessAfterInitialization(expected, "any-bean-name");
+
+    assertThat(actual).isSameAs(expected);
+  }
+
+  @Test
+  public void testMongoClientBeansReplacedWithTracingClient() {
+
+    final MongoClient client = new MongoClient(new MongoClientURI("mongodb://localhost/test", MongoClientOptions.builder()));
+
+    final Object actual = processor.postProcessAfterInitialization(client, "any-bean-name");
+
+    assertThat(actual).isInstanceOf(TracingMongoClient.class);
+  }
+}

--- a/instrument-starters/opentracing-spring-cloud-mongo-starter/src/test/java/io/opentracing/contrib/spring/cloud/mongo/TracingMongoClientPostProcessorTest.java
+++ b/instrument-starters/opentracing-spring-cloud-mongo-starter/src/test/java/io/opentracing/contrib/spring/cloud/mongo/TracingMongoClientPostProcessorTest.java
@@ -14,6 +14,7 @@
 package io.opentracing.contrib.spring.cloud.mongo;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
 
 import com.mongodb.MongoClient;
 import com.mongodb.MongoClientOptions;
@@ -54,5 +55,15 @@ public class TracingMongoClientPostProcessorTest {
     final Object actual = processor.postProcessAfterInitialization(client, "any-bean-name");
 
     assertThat(actual).isInstanceOf(TracingMongoClient.class);
+  }
+
+  @Test
+  public void testTracingMongoClientBeanNotWrapped() {
+
+    final TracingMongoClient tracingClientMock = mock(TracingMongoClient.class);
+
+    final Object actual = processor.postProcessAfterInitialization(tracingClientMock, "any-bean-name");
+
+    assertThat(actual).isSameAs(tracingClientMock);
   }
 }


### PR DESCRIPTION
When using this starter a `TracingMongoClient` bean is created whenever `MongoClient` is on the class path. This replaces the behavior of `MongoAutoConfiguration`, which only creates a `MongoClient` bean if:
1. `MongoDbFactory` is not present in the context.
2. `MongoClient` is not present in the context.
3. `MongoClient.class` is on the class path.

This change takes a slightly different approach that delegates to `MongoAutoConfiguration` for creation of a `MongoClient` when appropriate and focuses more narrowly on creation of `TracingMongoClient` for any `MongoClient` beans present. In addition this setup will work in situations where more than one `MongoClient` bean is present in the context.

This approach will replace a `MongoClient` bean with a `TracingMongoClient` bean when:
1. A `Tracer` bean is present in the context.
2. A `MongoClient` bean is present in the context.
3. The configuration is not disabled via `opentracing.spring.cloud.mongo.enabled`.

This is accomplished using a new implementation of `BeanPostProcessor` that creates a `TracingMongoClient` whenever it encounters a `MongoClient`.