### PR TITLE
Add tracing for ThreadPoolTaskScheduler

### DIFF
--- a/instrument-starters/opentracing-spring-cloud-core/src/main/java/io/opentracing/contrib/spring/cloud/async/instrument/TracedThreadPoolTaskScheduler.java
+++ b/instrument-starters/opentracing-spring-cloud-core/src/main/java/io/opentracing/contrib/spring/cloud/async/instrument/TracedThreadPoolTaskScheduler.java
@@ -1,0 +1,286 @@
+/**
+ * Copyright 2017-2019 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.contrib.spring.cloud.async.instrument;
+
+import io.opentracing.Tracer;
+import io.opentracing.contrib.concurrent.TracedCallable;
+import io.opentracing.contrib.concurrent.TracedRunnable;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Date;
+import java.util.concurrent.Callable;
+import java.util.concurrent.Future;
+import java.util.concurrent.RejectedExecutionHandler;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.ScheduledFuture;
+import java.util.concurrent.ScheduledThreadPoolExecutor;
+import java.util.concurrent.ThreadFactory;
+import org.springframework.lang.Nullable;
+import org.springframework.scheduling.Trigger;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.util.ErrorHandler;
+import org.springframework.util.concurrent.ListenableFuture;
+
+
+/**
+ * A traced version of {@code TracedThreadPoolTaskScheduler}.
+ *
+ * @author cbono
+ */
+public class TracedThreadPoolTaskScheduler
+    extends ThreadPoolTaskScheduler {
+
+  private final Tracer tracer;
+  private final ThreadPoolTaskScheduler delegate;
+
+  public TracedThreadPoolTaskScheduler(Tracer tracer, ThreadPoolTaskScheduler delegate) {
+    this.tracer = tracer;
+    this.delegate = delegate;
+  }
+
+  @Override
+  public void setPoolSize(int poolSize) {
+    delegate.setPoolSize(poolSize);
+  }
+
+  @Override
+  public void setRemoveOnCancelPolicy(boolean removeOnCancelPolicy) {
+    delegate.setRemoveOnCancelPolicy(removeOnCancelPolicy);
+  }
+
+  @Override
+  public void setErrorHandler(ErrorHandler errorHandler) {
+    delegate.setErrorHandler(errorHandler);
+  }
+
+  @Override
+  public ScheduledExecutorService getScheduledExecutor()
+      throws IllegalStateException {
+    return delegate.getScheduledExecutor();
+  }
+
+  @Override
+  public ScheduledThreadPoolExecutor getScheduledThreadPoolExecutor()
+      throws IllegalStateException {
+    return delegate.getScheduledThreadPoolExecutor();
+  }
+
+  @Override
+  public int getPoolSize() {
+    return delegate.getPoolSize();
+  }
+
+  @Override
+  public boolean isRemoveOnCancelPolicy() {
+    return delegate.isRemoveOnCancelPolicy();
+  }
+
+  @Override
+  public int getActiveCount() {
+    return delegate.getActiveCount();
+  }
+
+  @Override
+  public void execute(Runnable task) {
+    delegate.execute(new TracedRunnable(task, tracer));
+  }
+
+  @Override
+  public void execute(Runnable task, long startTimeout) {
+    delegate.execute(new TracedRunnable(task, tracer), startTimeout);
+  }
+
+  @Override
+  public Future<?> submit(Runnable task) {
+    return delegate.submit(new TracedRunnable(task, tracer));
+  }
+
+  @Override
+  public <T> Future<T> submit(Callable<T> task) {
+    return delegate.submit(new TracedCallable<>(task, tracer));
+  }
+
+  @Override
+  public ListenableFuture<?> submitListenable(Runnable task) {
+    return delegate.submitListenable(new TracedRunnable(task, tracer));
+  }
+
+  @Override
+  public <T> ListenableFuture<T> submitListenable(Callable<T> task) {
+    return delegate.submitListenable(new TracedCallable<>(task, tracer));
+  }
+
+  @Override
+  @Nullable
+  public ScheduledFuture<?> schedule(Runnable task, Trigger trigger) {
+    return delegate.schedule(new TracedRunnable(task, tracer), trigger);
+  }
+
+  @Override
+  public ScheduledFuture<?> schedule(Runnable task, Date startTime) {
+    return delegate.schedule(new TracedRunnable(task, tracer), startTime);
+  }
+
+  @Override
+  public ScheduledFuture<?> schedule(Runnable task, Instant startTime) {
+    return delegate.schedule(new TracedRunnable(task, tracer), startTime);
+  }
+
+  @Override
+  public ScheduledFuture<?> scheduleAtFixedRate(Runnable task, Date startTime, long period) {
+    return delegate.scheduleAtFixedRate(new TracedRunnable(task, tracer), startTime, period);
+  }
+
+  @Override
+  public ScheduledFuture<?> scheduleAtFixedRate(Runnable task, Instant startTime, Duration period) {
+    return delegate.scheduleAtFixedRate(new TracedRunnable(task, tracer), startTime, period);
+  }
+
+  @Override
+  public ScheduledFuture<?> scheduleAtFixedRate(Runnable task, long period) {
+    return delegate.scheduleAtFixedRate(new TracedRunnable(task, tracer), period);
+  }
+
+  @Override
+  public ScheduledFuture<?> scheduleAtFixedRate(Runnable task, Duration period) {
+    return delegate.scheduleAtFixedRate(new TracedRunnable(task, tracer), period);
+  }
+
+  @Override
+  public ScheduledFuture<?> scheduleWithFixedDelay(Runnable task, Date startTime, long delay) {
+    return delegate.scheduleWithFixedDelay(new TracedRunnable(task, tracer), startTime, delay);
+  }
+
+  @Override
+  public ScheduledFuture<?> scheduleWithFixedDelay(Runnable task, long delay) {
+    return delegate.scheduleWithFixedDelay(new TracedRunnable(task, tracer), delay);
+  }
+
+  @Override
+  public ScheduledFuture<?> scheduleWithFixedDelay(Runnable task, Instant startTime,
+      Duration delay) {
+    return delegate.scheduleWithFixedDelay(new TracedRunnable(task, tracer), startTime, delay);
+  }
+
+  @Override
+  public ScheduledFuture<?> scheduleWithFixedDelay(Runnable task, Duration delay) {
+    return delegate.scheduleWithFixedDelay(new TracedRunnable(task, tracer), delay);
+  }
+
+  @Override
+  public void setThreadFactory(ThreadFactory threadFactory) {
+    delegate.setThreadFactory(threadFactory);
+  }
+
+  @Override
+  public void setThreadNamePrefix(String threadNamePrefix) {
+    delegate.setThreadNamePrefix(threadNamePrefix);
+  }
+
+  @Override
+  public void setRejectedExecutionHandler(RejectedExecutionHandler rejectedExecutionHandler) {
+    delegate.setRejectedExecutionHandler(rejectedExecutionHandler);
+  }
+
+  @Override
+  public void setWaitForTasksToCompleteOnShutdown(boolean waitForJobsToCompleteOnShutdown) {
+    delegate.setWaitForTasksToCompleteOnShutdown(waitForJobsToCompleteOnShutdown);
+  }
+
+  @Override
+  public void setAwaitTerminationSeconds(int awaitTerminationSeconds) {
+    delegate.setAwaitTerminationSeconds(awaitTerminationSeconds);
+  }
+
+  @Override
+  public void setBeanName(String name) {
+    delegate.setBeanName(name);
+  }
+
+  @Override
+  public void afterPropertiesSet() {
+    delegate.afterPropertiesSet();
+  }
+
+  @Override
+  public void initialize() {
+    delegate.initialize();
+  }
+
+  @Override
+  public void destroy() {
+    delegate.destroy();
+  }
+
+  @Override
+  public void shutdown() {
+    delegate.shutdown();
+  }
+
+  @Override
+  public Thread newThread(Runnable runnable) {
+    return delegate.newThread(runnable);
+  }
+
+  @Override
+  public String getThreadNamePrefix() {
+    return delegate.getThreadNamePrefix();
+  }
+
+  @Override
+  public void setThreadPriority(int threadPriority) {
+    delegate.setThreadPriority(threadPriority);
+  }
+
+  @Override
+  public int getThreadPriority() {
+    return delegate.getThreadPriority();
+  }
+
+  @Override
+  public void setDaemon(boolean daemon) {
+    delegate.setDaemon(daemon);
+  }
+
+  @Override
+  public boolean isDaemon() {
+    return delegate.isDaemon();
+  }
+
+  @Override
+  public void setThreadGroupName(String name) {
+    delegate.setThreadGroupName(name);
+  }
+
+  @Override
+  public void setThreadGroup(ThreadGroup threadGroup) {
+    delegate.setThreadGroup(threadGroup);
+  }
+
+  @Override
+  @Nullable
+  public ThreadGroup getThreadGroup() {
+    return delegate.getThreadGroup();
+  }
+
+  @Override
+  public Thread createThread(Runnable runnable) {
+    return delegate.createThread(runnable);
+  }
+
+  @Override
+  public boolean prefersShortLivedTasks() {
+    return delegate.prefersShortLivedTasks();
+  }
+}

--- a/instrument-starters/opentracing-spring-cloud-core/src/test/java/io/opentracing/contrib/spring/cloud/async/instrument/TracedThreadPoolTaskSchedulerIntegrationTest.java
+++ b/instrument-starters/opentracing-spring-cloud-core/src/test/java/io/opentracing/contrib/spring/cloud/async/instrument/TracedThreadPoolTaskSchedulerIntegrationTest.java
@@ -1,0 +1,129 @@
+/**
+ * Copyright 2017-2019 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.contrib.spring.cloud.async.instrument;
+
+import static org.awaitility.Awaitility.await;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.fail;
+
+import io.opentracing.Scope;
+import io.opentracing.Span;
+import io.opentracing.contrib.spring.cloud.MockTracingConfiguration;
+import io.opentracing.contrib.spring.cloud.TestUtils;
+import io.opentracing.mock.MockSpan;
+import io.opentracing.mock.MockTracer;
+import java.time.Instant;
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Executor;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.RejectedExecutionException;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.core.task.SimpleAsyncTaskExecutor;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+/**
+ * @author cbono
+ */
+@SpringBootTest(classes = {
+    MockTracingConfiguration.class,
+    TracedThreadPoolTaskSchedulerIntegrationTest.TestConfiguration.class
+})
+@RunWith(SpringJUnit4ClassRunner.class)
+public class TracedThreadPoolTaskSchedulerIntegrationTest {
+
+  @Configuration
+  static class TestConfiguration {
+
+    @Bean
+    public ThreadPoolTaskScheduler threadPoolTaskScheduler() {
+      final ThreadPoolTaskScheduler executor = new ThreadPoolTaskScheduler();
+      executor.initialize();
+      return executor;
+    }
+  }
+
+  @Autowired
+  private MockTracer mockTracer;
+
+  @Autowired
+  @Qualifier("threadPoolTaskScheduler")
+  private ThreadPoolTaskScheduler threadPoolTaskScheduler;
+
+  @Before
+  public void before() {
+    mockTracer.reset();
+  }
+
+  @Test
+  public void testExecute() {
+    final Span span = mockTracer.buildSpan("5150").start();
+    try (Scope scope = mockTracer.activateSpan(span)) {
+      final CompletableFuture<String> completableFuture = CompletableFuture.supplyAsync(() -> {
+        mockTracer.buildSpan("child").start().finish();
+        return "ok";
+      }, threadPoolTaskScheduler);
+      completableFuture.join();
+    }
+    span.finish();
+    await().until(() -> mockTracer.finishedSpans().size() == 2);
+
+    final List<MockSpan> mockSpans = mockTracer.finishedSpans();
+    assertEquals(2, mockSpans.size());
+    TestUtils.assertSameTraceId(mockSpans);
+  }
+
+  @Test
+  public void testSumbit() throws Exception {
+    final Span span = mockTracer.buildSpan("5150").start();
+    try (Scope scope = mockTracer.activateSpan(span)) {
+      final Future<?> child = threadPoolTaskScheduler.submit(() -> mockTracer.buildSpan("child").start().finish());
+      child.get();
+    }
+    span.finish();
+    await().until(() -> mockTracer.finishedSpans().size() == 2);
+
+    final List<MockSpan> mockSpans = mockTracer.finishedSpans();
+    assertEquals(2, mockSpans.size());
+    TestUtils.assertSameTraceId(mockSpans);
+  }
+
+  @Test
+  public void testSchedule() throws Exception {
+    final Span span = mockTracer.buildSpan("5150").start();
+    try (Scope scope = mockTracer.activateSpan(span)) {
+      final Future<?> child = threadPoolTaskScheduler.schedule(
+          () -> mockTracer.buildSpan("child").start().finish(),
+          Instant.now().plusSeconds(5));
+      child.get();
+    }
+    span.finish();
+    await().until(() -> mockTracer.finishedSpans().size() == 2);
+
+    final List<MockSpan> mockSpans = mockTracer.finishedSpans();
+    assertEquals(2, mockSpans.size());
+    TestUtils.assertSameTraceId(mockSpans);
+  }
+}

--- a/instrument-starters/opentracing-spring-cloud-core/src/test/java/io/opentracing/contrib/spring/cloud/async/instrument/TracedThreadPoolTaskSchedulerTest.java
+++ b/instrument-starters/opentracing-spring-cloud-core/src/test/java/io/opentracing/contrib/spring/cloud/async/instrument/TracedThreadPoolTaskSchedulerTest.java
@@ -1,0 +1,413 @@
+/**
+ * Copyright 2017-2019 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.contrib.spring.cloud.async.instrument;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+
+import io.opentracing.Tracer;
+import io.opentracing.contrib.concurrent.TracedCallable;
+import io.opentracing.contrib.concurrent.TracedRunnable;
+import io.opentracing.contrib.spring.cloud.async.TracedExecutorTest;
+import java.lang.reflect.Field;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.Date;
+import java.util.concurrent.Callable;
+import java.util.concurrent.RejectedExecutionHandler;
+import java.util.concurrent.ThreadFactory;
+import org.junit.Test;
+import org.mockito.ArgumentCaptor;
+import org.springframework.scheduling.Trigger;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.util.ErrorHandler;
+import org.springframework.util.ReflectionUtils;
+
+
+/**
+ * Unit tests all API surface area for TracedThreadPoolTaskScheduler. There is value in integration testing these
+ * via {@code SpringBootTest} but due to the amount of methods we rely on unit tests as a whole and then run a
+ * couple of the methods through integration tests in {@link TracedThreadPoolTaskSchedulerIntegrationTest}. The
+ * thinking is that the plumping that makes it all work is the wrapping in TracedRunnable/TracedCallable so
+ * long as we verify that in unit tests all should be good.
+ *
+ * @author cbono
+ */
+public class TracedThreadPoolTaskSchedulerTest {
+
+  private static final Field TRACED_RUNNABLE_DELEGATE_FIELD = ReflectionUtils.findField(TracedRunnable.class, "delegate");
+  private static final Field TRACED_RUNNABLE_TRACER_FIELD = ReflectionUtils.findField(TracedRunnable.class, "tracer");
+  private static final Field TRACED_CALLABLE_DELEGATE_FIELD = ReflectionUtils.findField(TracedCallable.class, "delegate");
+  private static final Field TRACED_CALLABLE_TRACER_FIELD = ReflectionUtils.findField(TracedCallable.class, "tracer");
+  static {
+    ReflectionUtils.makeAccessible(TRACED_RUNNABLE_DELEGATE_FIELD);
+    ReflectionUtils.makeAccessible(TRACED_RUNNABLE_TRACER_FIELD);
+    ReflectionUtils.makeAccessible(TRACED_CALLABLE_DELEGATE_FIELD);
+    ReflectionUtils.makeAccessible(TRACED_CALLABLE_TRACER_FIELD);
+  }
+
+  private final Runnable mockRunnable = mock(Runnable.class);
+  private final Callable mockCallable = mock(Callable.class);
+  private final Tracer mockTracer = mock(Tracer.class);
+  private final ThreadPoolTaskScheduler delegate = mock(ThreadPoolTaskScheduler.class);
+  private final TracedThreadPoolTaskScheduler scheduler = new TracedThreadPoolTaskScheduler(
+      mockTracer, delegate);
+
+  @Test
+  public void setPoolSize() {
+    scheduler.setPoolSize(10);
+    verify(delegate).setPoolSize(10);
+  }
+
+  @Test
+  public void setRemoveOnCancelPolicy() {
+    scheduler.setRemoveOnCancelPolicy(true);
+    verify(delegate).setRemoveOnCancelPolicy(true);
+  }
+
+  @Test
+  public void setErrorHandler() {
+    final ErrorHandler errorHandler = mock(ErrorHandler.class);
+    scheduler.setErrorHandler(errorHandler);
+    verify(delegate).setErrorHandler(errorHandler);
+  }
+
+  @Test
+  public void getScheduledExecutor() {
+    scheduler.getScheduledExecutor();
+    verify(delegate).getScheduledExecutor();
+  }
+
+  @Test
+  public void getScheduledThreadPoolExecutor() {
+    scheduler.getScheduledThreadPoolExecutor();
+    verify(delegate).getScheduledThreadPoolExecutor();
+  }
+
+  @Test
+  public void getPoolSize() {
+    scheduler.getPoolSize();
+    verify(delegate).getPoolSize();
+  }
+
+  @Test
+  public void isRemoveOnCancelPolicy() {
+    scheduler.isRemoveOnCancelPolicy();
+    verify(delegate).isRemoveOnCancelPolicy();
+  }
+
+  @Test
+  public void getActiveCount() {
+    scheduler.getActiveCount();
+    verify(delegate).getActiveCount();
+  }
+
+  @Test
+  public void execute() {
+    final ArgumentCaptor<TracedRunnable> argumentCaptor = ArgumentCaptor.forClass(TracedRunnable.class);
+    scheduler.execute(mockRunnable);
+    verify(delegate).execute(argumentCaptor.capture());
+    verifyTracedRunnable(argumentCaptor.getValue(), mockRunnable, mockTracer);
+  }
+
+  @Test
+  public void executeWithTimeout() {
+    final ArgumentCaptor<TracedRunnable> argumentCaptor = ArgumentCaptor.forClass(TracedRunnable.class);
+    scheduler.execute(mockRunnable, 1000L);
+    verify(delegate).execute(argumentCaptor.capture(), eq(1000L));
+    verifyTracedRunnable(argumentCaptor.getValue(), mockRunnable, mockTracer);
+  }
+
+  @Test
+  public void submitRunnable() {
+    final ArgumentCaptor<TracedRunnable> argumentCaptor = ArgumentCaptor.forClass(TracedRunnable.class);
+    scheduler.submit(mockRunnable);
+    verify(delegate).submit(argumentCaptor.capture());
+    verifyTracedRunnable(argumentCaptor.getValue(), mockRunnable, mockTracer);
+  }
+
+  @Test
+  public void submitCallable() {
+    final ArgumentCaptor<TracedCallable> argumentCaptor = ArgumentCaptor.forClass(TracedCallable.class);
+    scheduler.submit(mockCallable);
+    verify(delegate).submit(argumentCaptor.capture());
+    verifyTracedCallable(argumentCaptor.getValue(), mockCallable, mockTracer);
+  }
+
+  @Test
+  public void submitListenableRunnable() {
+    final ArgumentCaptor<TracedRunnable> argumentCaptor = ArgumentCaptor.forClass(TracedRunnable.class);
+    scheduler.submitListenable(mockRunnable);
+    verify(delegate).submitListenable(argumentCaptor.capture());
+    verifyTracedRunnable(argumentCaptor.getValue(), mockRunnable, mockTracer);
+  }
+
+  @Test
+  public void submitListenableCallable() {
+    final ArgumentCaptor<TracedCallable> argumentCaptor = ArgumentCaptor.forClass(TracedCallable.class);
+    scheduler.submitListenable(mockCallable);
+    verify(delegate).submitListenable(argumentCaptor.capture());
+    verifyTracedCallable(argumentCaptor.getValue(), mockCallable, mockTracer);
+  }
+
+  @Test
+  public void scheduleWithTrigger() {
+    final ArgumentCaptor<TracedRunnable> argumentCaptor = ArgumentCaptor.forClass(TracedRunnable.class);
+    final Trigger trigger = mock(Trigger.class);
+    scheduler.schedule(mockRunnable, trigger);
+    verify(delegate).schedule(argumentCaptor.capture(), eq(trigger));
+    verifyTracedRunnable(argumentCaptor.getValue(), mockRunnable, mockTracer);
+  }
+
+  @Test
+  public void scheduleWithDate() {
+    final ArgumentCaptor<TracedRunnable> argumentCaptor = ArgumentCaptor.forClass(TracedRunnable.class);
+    final Date date = mock(Date.class);
+    scheduler.schedule(mockRunnable, date);
+    verify(delegate).schedule(argumentCaptor.capture(), eq(date));
+    verifyTracedRunnable(argumentCaptor.getValue(), mockRunnable, mockTracer);
+  }
+
+  @Test
+  public void scheduleWithInstant() {
+    final ArgumentCaptor<TracedRunnable> argumentCaptor = ArgumentCaptor.forClass(TracedRunnable.class);
+    final Instant instant = Instant.now();
+    scheduler.schedule(mockRunnable, instant);
+    verify(delegate).schedule(argumentCaptor.capture(), eq(instant));
+    verifyTracedRunnable(argumentCaptor.getValue(), mockRunnable, mockTracer);
+  }
+
+  @Test
+  public void scheduleAtFixedRateWithDateAndLong() {
+    final ArgumentCaptor<TracedRunnable> argumentCaptor = ArgumentCaptor.forClass(TracedRunnable.class);
+    final Date date = new Date();
+    scheduler.scheduleAtFixedRate(mockRunnable, date, 1000L);
+    verify(delegate).scheduleAtFixedRate(argumentCaptor.capture(), eq(date), eq(1000L));
+    verifyTracedRunnable(argumentCaptor.getValue(), mockRunnable, mockTracer);
+  }
+
+  @Test
+  public void scheduleAtFixedRateWithInstantAndDuration() {
+    final ArgumentCaptor<TracedRunnable> argumentCaptor = ArgumentCaptor.forClass(TracedRunnable.class);
+    final Instant instant = Instant.now();
+    final Duration duration = Duration.ofMinutes(1);
+    scheduler.scheduleAtFixedRate(mockRunnable, instant, duration);
+    verify(delegate).scheduleAtFixedRate(argumentCaptor.capture(), eq(instant), eq(duration));
+    verifyTracedRunnable(argumentCaptor.getValue(), mockRunnable, mockTracer);
+  }
+
+  @Test
+  public void scheduleAtFixedRateWithLong() {
+    final ArgumentCaptor<TracedRunnable> argumentCaptor = ArgumentCaptor.forClass(TracedRunnable.class);
+    scheduler.scheduleAtFixedRate(mockRunnable, 1000L);
+    verify(delegate).scheduleAtFixedRate(argumentCaptor.capture(), eq(1000L));
+    verifyTracedRunnable(argumentCaptor.getValue(), mockRunnable, mockTracer);
+  }
+
+  @Test
+  public void scheduleAtFixedRateWithDuration() {
+    final ArgumentCaptor<TracedRunnable> argumentCaptor = ArgumentCaptor.forClass(TracedRunnable.class);
+    final Duration duration = Duration.ofMinutes(5);
+    scheduler.scheduleAtFixedRate(mockRunnable, duration);
+    verify(delegate).scheduleAtFixedRate(argumentCaptor.capture(), eq(duration));
+    verifyTracedRunnable(argumentCaptor.getValue(), mockRunnable, mockTracer);
+  }
+
+  @Test
+  public void scheduleWithFixedDelayWithDateAndLong() {
+    final ArgumentCaptor<TracedRunnable> argumentCaptor = ArgumentCaptor.forClass(TracedRunnable.class);
+    final Date date = new Date();
+    scheduler.scheduleWithFixedDelay(mockRunnable, date, 1000L);
+    verify(delegate).scheduleWithFixedDelay(argumentCaptor.capture(), eq(date), eq(1000L));
+    verifyTracedRunnable(argumentCaptor.getValue(), mockRunnable, mockTracer);
+  }
+
+  @Test
+  public void scheduleWithFixedDelayWithLong() {
+    final ArgumentCaptor<TracedRunnable> argumentCaptor = ArgumentCaptor.forClass(TracedRunnable.class);
+    scheduler.scheduleWithFixedDelay(mockRunnable, 1000L);
+    verify(delegate).scheduleWithFixedDelay(argumentCaptor.capture(), eq(1000L));
+    verifyTracedRunnable(argumentCaptor.getValue(), mockRunnable, mockTracer);
+  }
+
+  @Test
+  public void scheduleWithFixedDelayWithInstantAndDuration() {
+    final ArgumentCaptor<TracedRunnable> argumentCaptor = ArgumentCaptor.forClass(TracedRunnable.class);
+    final Instant instant = Instant.now();
+    final Duration duration = Duration.ofMinutes(1);
+    scheduler.scheduleWithFixedDelay(mockRunnable, instant, duration);
+    verify(delegate).scheduleWithFixedDelay(argumentCaptor.capture(), eq(instant), eq(duration));
+    verifyTracedRunnable(argumentCaptor.getValue(), mockRunnable, mockTracer);
+  }
+
+  @Test
+  public void scheduleWithFixedDelayWithDuration() {
+    final ArgumentCaptor<TracedRunnable> argumentCaptor = ArgumentCaptor.forClass(TracedRunnable.class);
+    final Duration duration = Duration.ofMinutes(5);
+    scheduler.scheduleWithFixedDelay(mockRunnable, duration);
+    verify(delegate).scheduleWithFixedDelay(argumentCaptor.capture(), eq(duration));
+    verifyTracedRunnable(argumentCaptor.getValue(), mockRunnable, mockTracer);
+  }
+
+  private void verifyTracedRunnable(final TracedRunnable tracedRunnable, final Runnable task, final Tracer tracer) {
+    final Runnable actualTask = (Runnable) ReflectionUtils.getField(TRACED_RUNNABLE_DELEGATE_FIELD, tracedRunnable);
+    final Tracer actualTracer = (Tracer) ReflectionUtils.getField(TRACED_RUNNABLE_TRACER_FIELD, tracedRunnable);
+    assertThat(actualTask).isEqualTo(task);
+    assertThat(actualTracer).isEqualTo(tracer);
+  }
+
+  private void verifyTracedCallable(final TracedCallable tracedCallable, final Callable task, final Tracer tracer) {
+    final Callable actualTask = (Callable) ReflectionUtils.getField(TRACED_CALLABLE_DELEGATE_FIELD, tracedCallable);
+    final Tracer actualTracer = (Tracer) ReflectionUtils.getField(TRACED_CALLABLE_TRACER_FIELD, tracedCallable);
+    assertThat(actualTask).isEqualTo(task);
+    assertThat(actualTracer).isEqualTo(tracer);
+  }
+
+  @Test
+  public void setThreadFactory() {
+    final ThreadFactory threadFactory = mock(ThreadFactory.class);
+    scheduler.setThreadFactory(threadFactory);
+    verify(delegate).setThreadFactory(threadFactory);
+  }
+
+  @Test
+  public void setThreadNamePrefix() {
+    final String threadNamePrefix = "c137";
+    scheduler.setThreadNamePrefix(threadNamePrefix);
+    verify(delegate).setThreadNamePrefix(threadNamePrefix);
+  }
+
+  @Test
+  public void setRejectedExecutionHandler() {
+    final RejectedExecutionHandler rejectedExecutionHandler = mock(RejectedExecutionHandler.class);
+    scheduler.setRejectedExecutionHandler(rejectedExecutionHandler);
+    verify(delegate).setRejectedExecutionHandler(rejectedExecutionHandler);
+  }
+
+  @Test
+  public void setWaitForTasksToCompleteOnShutdown() {
+    scheduler.setWaitForTasksToCompleteOnShutdown(true);
+    verify(delegate).setWaitForTasksToCompleteOnShutdown(true);
+  }
+
+  @Test
+  public void setAwaitTerminationSeconds() {
+    scheduler.setAwaitTerminationSeconds(5);
+    verify(delegate).setAwaitTerminationSeconds(5);
+  }
+
+  @Test
+  public void setBeanName() {
+    final String name = "gazorp";
+    scheduler.setBeanName(name);
+    verify(delegate).setBeanName(name);
+  }
+
+  @Test
+  public void afterPropertiesSet() {
+    scheduler.afterPropertiesSet();
+    verify(delegate).afterPropertiesSet();
+  }
+
+  @Test
+  public void initialize() {
+    scheduler.initialize();
+    verify(delegate).initialize();
+  }
+
+  @Test
+  public void destroy() {
+    scheduler.destroy();
+    verify(delegate).destroy();
+  }
+
+  @Test
+  public void shutdown() {
+    scheduler.shutdown();
+    verify(delegate).shutdown();
+  }
+
+  @Test
+  public void newThread() {
+    final Runnable runnable = mock(Runnable.class);
+    scheduler.newThread(runnable);
+    verify(delegate).newThread(runnable);
+  }
+
+  @Test
+  public void getThreadNamePrefix() {
+    scheduler.getThreadNamePrefix();
+    verify(delegate).getThreadNamePrefix();
+  }
+
+  @Test
+  public void setThreadPriority() {
+    final int threadPriority = 5150;
+    scheduler.setThreadPriority(threadPriority);
+    verify(delegate).setThreadPriority(threadPriority);
+  }
+
+  @Test
+  public void getThreadPriority() {
+    scheduler.getThreadPriority();
+    verify(delegate).getThreadPriority();
+  }
+
+  @Test
+  public void setDaemon() {
+    scheduler.setDaemon(true);
+    verify(delegate).setDaemon(true);
+  }
+
+  @Test
+  public void isDaemon() {
+    scheduler.isDaemon();
+    verify(delegate).isDaemon();
+  }
+
+  @Test
+  public void setThreadGroupName() {
+    final String name = "crombopulous";
+    scheduler.setThreadGroupName(name);
+    verify(delegate).setThreadGroupName(name);
+  }
+
+  @Test
+  public void setThreadGroup() {
+    final ThreadGroup threadGroup = mock(ThreadGroup.class);
+    scheduler.setThreadGroup(threadGroup);
+    verify(delegate).setThreadGroup(threadGroup);
+  }
+
+  @Test
+  public void getThreadGroup() {
+    scheduler.getThreadGroup();
+    verify(delegate).getThreadGroup();
+  }
+
+  @Test
+  public void createThread() {
+    final Runnable runnable = mock(Runnable.class);
+    scheduler.createThread(runnable);
+    verify(delegate).createThread(runnable);
+  }
+
+  @Test
+  public void prefersShortLivedTasks() {
+    scheduler.prefersShortLivedTasks();
+    verify(delegate).prefersShortLivedTasks();
+  }
+}


### PR DESCRIPTION
This fixes #228 

This merge adds tracing for ThreadPoolTaskScheduler and follows same approach as done in https://github.com/opentracing-contrib/java-spring-cloud/pull/231