### PR TITLE
Fix CustomAsyncConfigurerAutoConfiguration creates TracedAsyncConfigurer with null tracer

### DIFF
--- a/instrument-starters/opentracing-spring-cloud-core/src/test/java/io/opentracing/contrib/spring/cloud/async/AsyncConfigurerTest.java
+++ b/instrument-starters/opentracing-spring-cloud-core/src/test/java/io/opentracing/contrib/spring/cloud/async/AsyncConfigurerTest.java
@@ -13,6 +13,10 @@
  */
 package io.opentracing.contrib.spring.cloud.async;
 
+import static org.assertj.core.api.Assertions.assertThat;
+
+import io.opentracing.Tracer;
+import io.opentracing.contrib.concurrent.TracedExecutor;
 import io.opentracing.contrib.spring.cloud.MockTracingConfiguration;
 import io.opentracing.contrib.spring.cloud.async.instrument.TracedAsyncConfigurer;
 import java.util.concurrent.Executor;
@@ -27,12 +31,11 @@ import org.springframework.scheduling.annotation.AsyncConfigurerSupport;
 import org.springframework.scheduling.annotation.EnableAsync;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-
-
-
+import org.springframework.test.util.ReflectionTestUtils;
 
 /**
- * @Author wuyupeng
+ * @author wuyupeng
+ * @author Tadaya Tsuyukubo
  **/
 @SpringBootTest(classes = {AsyncConfigurerTest.AsyncConfigurerConfig.class, MockTracingConfiguration.class, CustomAsyncConfigurerAutoConfiguration.class})
 @RunWith(SpringJUnit4ClassRunner.class)
@@ -59,5 +62,11 @@ public class AsyncConfigurerTest {
   @Test
   public void testIsTracedAsyncConfigurer() {
     BDDAssertions.then(asyncConfigurer).isInstanceOf(TracedAsyncConfigurer.class);
+
+    assertThat(this.asyncConfigurer.getAsyncExecutor()).isInstanceOfSatisfying(TracedExecutor.class, tracedExecutor -> {
+      Tracer tracer = (Tracer) ReflectionTestUtils.getField(tracedExecutor, "tracer");
+      assertThat(tracer).isNotNull();
+    });
+
   }
 }

--- a/instrument-starters/opentracing-spring-cloud-core/src/test/java/io/opentracing/contrib/spring/cloud/async/CustomAsyncConfigurerAutoConfigurationTest.java
+++ b/instrument-starters/opentracing-spring-cloud-core/src/test/java/io/opentracing/contrib/spring/cloud/async/CustomAsyncConfigurerAutoConfigurationTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2018 The OpenTracing Authors
+ * Copyright 2017-2019 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -15,9 +15,13 @@ package io.opentracing.contrib.spring.cloud.async;
 
 import static org.assertj.core.api.BDDAssertions.then;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
+import io.opentracing.Tracer;
 import io.opentracing.contrib.spring.cloud.async.instrument.TracedAsyncConfigurer;
+import io.opentracing.mock.MockTracer;
 import org.junit.Test;
+import org.springframework.beans.factory.BeanFactory;
 import org.springframework.scheduling.annotation.AsyncConfigurer;
 
 /**
@@ -34,7 +38,12 @@ public class CustomAsyncConfigurerAutoConfigurationTest {
 
   @Test
   public void should_return_async_configurer_when_bean_instance_of_it() {
+    BeanFactory beanFactory = mock(BeanFactory.class);
+    when(beanFactory.getBean(Tracer.class)).thenReturn(new MockTracer());
+
     CustomAsyncConfigurerAutoConfiguration configuration = new CustomAsyncConfigurerAutoConfiguration();
+    configuration.setBeanFactory(beanFactory);
+
     Object bean = configuration
         .postProcessAfterInitialization(mock(AsyncConfigurer.class), "myAsync");
     then(bean).isInstanceOf(TracedAsyncConfigurer.class);


### PR DESCRIPTION
Hi,

Currently `CustomAsyncConfigurerAutoConfiguration` is broken.
This was due to the change introduced by https://github.com/opentracing-contrib/java-spring-cloud/pull/251. This change seems incomplete; it ends up creating `TracedAsyncConfigurer` with null in tracer.

Since `CustomAsyncConfigurerAutoConfiguration` is `@Configuration`, `BeanPostProcessor` and `PriorityOrdered`, it is handled very early stage of the spring's context creation and `@Autowired` annotated `Tracer` field is null. (autowiring doesn't happen since this is `@Configuration` and enhanced by CGLIB and auto-wiring by post processor seems not happening.)
At the end, when `postProcessAfterInitialization` is called, it creates `TracedAsyncConfigurer` with `null` in tracer argument.
Thus, created `TracedAsyncConfigurer` throws NPE for async task executions.

To fix the issue, instead of auto-wireing Tracer bean, look it up from `beanFactory` since it is kind of lazy lookup of the Tracer bean at `postProcessAfterInitialization` time.
Also, extended existing test to verify whether the tracer is set.
