### PR TITLE
Update opentracing-spring-mongo to 0.1.5

### DIFF
--- a/.settings.xml
+++ b/.settings.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <!--
 
-    Copyright 2017 The OpenTracing Authors
+    Copyright 2017-2020 The OpenTracing Authors
 
     Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
     in compliance with the License. You may obtain a copy of the License at

--- a/pom.xml
+++ b/pom.xml
@@ -83,7 +83,7 @@
     <version.io.opentracing.contrib-java-concurrent>0.3.0</version.io.opentracing.contrib-java-concurrent>
     <version.io.opentracing.contrib-opentracing-reactor>0.1.0</version.io.opentracing.contrib-opentracing-reactor>
     <version.io.opentracing.contrib-opentracing-rxjava-1>0.1.0</version.io.opentracing.contrib-opentracing-rxjava-1>
-    <version.io.opentracing.contrib-opentracing-spring-mongo>0.1.2</version.io.opentracing.contrib-opentracing-spring-mongo>
+    <version.io.opentracing.contrib-opentracing-spring-mongo>0.1.5</version.io.opentracing.contrib-opentracing-spring-mongo>
     <version.io.github.openfeign-feign-okhttp>10.2.0</version.io.github.openfeign-feign-okhttp>
     <version.io.github.openfeign.opentracing>0.3.0</version.io.github.openfeign.opentracing>
     <!-- spring-boot-starter-parent is a module of spring-boot-dependencies


### PR DESCRIPTION
The old approach of MongoAutoConfiguration conflicts with Spring Boot 2.2.x
Details of the new approach could be found in [issue-311925819](https://github.com/opentracing-contrib/java-spring-cloud/pull/242#issue-311925819)