### PR TITLE
Undo changes from "Prevent JDBC creating duplicate spans (#211)"

### DIFF
--- a/instrument-starters/opentracing-spring-cloud-jdbc-starter/src/main/java/io/opentracing/contrib/spring/cloud/jdbc/JdbcAspect.java
+++ b/instrument-starters/opentracing-spring-cloud-jdbc-starter/src/main/java/io/opentracing/contrib/spring/cloud/jdbc/JdbcAspect.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2019 The OpenTracing Authors
+ * Copyright 2017-2020 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/instrument-starters/opentracing-spring-cloud-jdbc-starter/src/main/java/io/opentracing/contrib/spring/cloud/jdbc/JdbcAspect.java
+++ b/instrument-starters/opentracing-spring-cloud-jdbc-starter/src/main/java/io/opentracing/contrib/spring/cloud/jdbc/JdbcAspect.java
@@ -52,8 +52,7 @@ public class JdbcAspect {
   @Around("execution(java.sql.Connection *.getConnection(..)) && target(javax.sql.DataSource)")
   public Object getConnection(final ProceedingJoinPoint pjp) throws Throwable {
     Connection conn = (Connection) pjp.proceed();
-    if (conn instanceof TracingConnection ||
-        conn.isWrapperFor(TracingConnection.class)) {
+    if (conn instanceof TracingConnection) {
       return conn;
     }
     String url = conn.getMetaData().getURL();


### PR DESCRIPTION
As pointed out by @pavolloffay  in #210 the method
boolean isWrapperFor(Class<?> iface) throws SQLException
expects an interface not a class. The change in #211 made the JdbcAspect unusable with Oracle JDBC as pointed out by @bromine0x23. Even in the thread #210 it is stated, that it should be rolled back.

So here comes the pull request for rolling back :-)

With best regards,
Lyca