### PR TITLE
Catch SQLException thrown by Oracle connection when asked if it wraps a TracingConnection.

### DIFF
--- a/instrument-starters/opentracing-spring-cloud-jdbc-starter/pom.xml
+++ b/instrument-starters/opentracing-spring-cloud-jdbc-starter/pom.xml
@@ -48,6 +48,12 @@
     </dependency>
 
     <dependency>
+      <groupId>io.opentracing.contrib</groupId>
+      <artifactId>common</artifactId>
+      <version>${version.io.opentracing.contrib-common}</version>
+    </dependency>
+
+    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-aop</artifactId>
     </dependency>

--- a/instrument-starters/opentracing-spring-cloud-jdbc-starter/src/main/java/io/opentracing/contrib/spring/cloud/jdbc/JdbcAspect.java
+++ b/instrument-starters/opentracing-spring-cloud-jdbc-starter/src/main/java/io/opentracing/contrib/spring/cloud/jdbc/JdbcAspect.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2019 The OpenTracing Authors
+ * Copyright 2017-2020 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at

--- a/instrument-starters/opentracing-spring-cloud-jdbc-starter/src/main/java/io/opentracing/contrib/spring/cloud/jdbc/JdbcAspect.java
+++ b/instrument-starters/opentracing-spring-cloud-jdbc-starter/src/main/java/io/opentracing/contrib/spring/cloud/jdbc/JdbcAspect.java
@@ -17,6 +17,7 @@ import io.opentracing.contrib.jdbc.ConnectionInfo;
 import io.opentracing.contrib.jdbc.TracingConnection;
 import io.opentracing.contrib.jdbc.parser.URLParser;
 import java.sql.Connection;
+import java.sql.SQLException;
 import java.util.Set;
 import javax.sql.DataSource;
 
@@ -52,10 +53,19 @@ public class JdbcAspect {
   @Around("execution(java.sql.Connection *.getConnection(..)) && target(javax.sql.DataSource)")
   public Object getConnection(final ProceedingJoinPoint pjp) throws Throwable {
     Connection conn = (Connection) pjp.proceed();
-    if (conn instanceof TracingConnection ||
-        conn.isWrapperFor(TracingConnection.class)) {
-      return conn;
+    try {
+      if (conn instanceof TracingConnection ||
+          conn.isWrapperFor(TracingConnection.class)) {
+        return conn;
+      }
+    } catch (SQLException ignored) {
+      /**
+       * Oracle JDBC driver throws this SQL exception: "Object does not wrap anything with requested interface".
+       *
+       * See {@link java.sql.Wrapper#isWrapperFor(Class)} for an explanation why this should not be.
+       */
     }
+
     String url = conn.getMetaData().getURL();
     ConnectionInfo connectionInfo = URLParser.parser(url);
     return new TracingConnection(conn, connectionInfo, withActiveSpanOnly, ignoredStatements);

--- a/instrument-starters/opentracing-spring-cloud-jdbc-starter/src/test/java/io/opentracing/contrib/spring/cloud/jdbc/JdbcTracingTest.java
+++ b/instrument-starters/opentracing-spring-cloud-jdbc-starter/src/test/java/io/opentracing/contrib/spring/cloud/jdbc/JdbcTracingTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2019 The OpenTracing Authors
+ * Copyright 2017-2020 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -22,6 +22,7 @@ import io.opentracing.contrib.jdbc.TracingConnection;
 import io.opentracing.mock.MockSpan;
 import io.opentracing.mock.MockTracer;
 import io.opentracing.tag.Tags;
+import io.opentracing.util.GlobalTracer;
 import java.sql.PreparedStatement;
 import java.sql.SQLException;
 import java.util.List;
@@ -31,6 +32,7 @@ import java.util.concurrent.Executors;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import javax.sql.DataSource;
+
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -57,6 +59,7 @@ public class JdbcTracingTest {
 
   @Before
   public void before() {
+    GlobalTracer.registerIfAbsent(tracer);
     tracer.reset();
   }
 

--- a/instrument-starters/opentracing-spring-cloud-reactor-starter/pom.xml
+++ b/instrument-starters/opentracing-spring-cloud-reactor-starter/pom.xml
@@ -71,5 +71,11 @@
       <version>${version.io.opentracing.contrib-opentracing-spring-web}</version>
       <scope>test</scope>
     </dependency>
+    <dependency>
+      <groupId>javax.annotation</groupId>
+      <artifactId>javax.annotation-api</artifactId>
+      <version>1.3.2</version>
+      <optional>true</optional>
+    </dependency>
   </dependencies>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -78,7 +78,8 @@
     <version.io.opentracing.contrib-opentracing-spring-jms>0.1.0</version.io.opentracing.contrib-opentracing-spring-jms>
     <version.io.opentracing.contrib-opentracing-spring-messaging>0.1.2</version.io.opentracing.contrib-opentracing-spring-messaging>
     <version.io.opentracing.contrib-opentracing-spring-rabbitmq>2.0.5</version.io.opentracing.contrib-opentracing-spring-rabbitmq>
-    <version.io.opentracing.contrib-java-jdbc>0.1.1</version.io.opentracing.contrib-java-jdbc>
+    <version.io.opentracing.contrib-java-jdbc>0.2.9-SNAPSHOT</version.io.opentracing.contrib-java-jdbc>
+    <version.io.opentracing.contrib-common>0.1.4</version.io.opentracing.contrib-common>
     <version.io.opentracing.contrib-opentracing-spring-redis>0.1.8</version.io.opentracing.contrib-opentracing-spring-redis>
     <version.io.opentracing.contrib-java-concurrent>0.3.0</version.io.opentracing.contrib-java-concurrent>
     <version.io.opentracing.contrib-opentracing-reactor>0.1.0</version.io.opentracing.contrib-opentracing-reactor>

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,7 @@
   <version>0.4.1-SNAPSHOT</version>
   <modules>
     <module>opentracing-spring-cloud-starter</module>
-    <module>/instrument-starters/opentracing-spring-cloud-core</module>
+    <module>instrument-starters/opentracing-spring-cloud-core</module>
     <module>instrument-starters/opentracing-spring-cloud-jdbc-starter</module>
     <module>instrument-starters/opentracing-spring-cloud-jms-starter</module>
     <module>instrument-starters/opentracing-spring-cloud-feign-starter</module>


### PR DESCRIPTION
Resolves #258 

Oracle Connections throw a SQLExecption when the `java.sql.Wrapper#isWrapperFor(Class)` method is invoked.
Simple fix to catch this error and return a wrapped connection.