### PR TITLE
Add Spring Kafka starter

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@ It contains auto-configurations which instruments and trace following Spring Boo
 * Hystrix
 * JMS
 * JDBC
+* Kafka
 * Mongo
 * Zuul
 * Reactor

--- a/instrument-starters/opentracing-spring-cloud-kafka-starter/pom.xml
+++ b/instrument-starters/opentracing-spring-cloud-kafka-starter/pom.xml
@@ -47,10 +47,8 @@
     <dependency>
       <groupId>org.springframework.kafka</groupId>
       <artifactId>spring-kafka</artifactId>
-      <scope>provided</scope>
+      <optional>true</optional>
     </dependency>
-
-
 
     <dependency>
       <groupId>org.springframework.boot</groupId>
@@ -58,8 +56,6 @@
       <scope>test</scope>
     </dependency>
   </dependencies>
-
-
 
   <build>
     <plugins>

--- a/instrument-starters/opentracing-spring-cloud-kafka-starter/pom.xml
+++ b/instrument-starters/opentracing-spring-cloud-kafka-starter/pom.xml
@@ -1,0 +1,79 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2017-2020 The OpenTracing Authors
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+    in compliance with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the License
+    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+    or implied. See the License for the specific language governing permissions and limitations under
+    the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <parent>
+    <artifactId>opentracing-spring-cloud-parent</artifactId>
+    <groupId>io.opentracing.contrib</groupId>
+    <version>0.5.1-SNAPSHOT</version>
+    <relativePath>../../</relativePath>
+  </parent>
+  <modelVersion>4.0.0</modelVersion>
+
+  <artifactId>opentracing-spring-cloud-kafka-starter</artifactId>
+
+  <properties>
+    <main.basedir>${project.basedir}/../..</main.basedir>
+  </properties>
+
+  <dependencies>
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-autoconfigure</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>io.opentracing.contrib</groupId>
+      <artifactId>opentracing-spring-tracer-configuration-starter</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>io.opentracing.contrib</groupId>
+      <artifactId>opentracing-kafka-spring</artifactId>
+    </dependency>
+
+    <dependency>
+      <groupId>org.springframework.kafka</groupId>
+      <artifactId>spring-kafka</artifactId>
+      <scope>provided</scope>
+    </dependency>
+
+
+
+    <dependency>
+      <groupId>org.springframework.boot</groupId>
+      <artifactId>spring-boot-starter-test</artifactId>
+      <scope>test</scope>
+    </dependency>
+  </dependencies>
+
+
+
+  <build>
+    <plugins>
+      <!-- Restart JVM between tests
+          artemis-starter and manual test creates Artemis broker which is bound to JVM
+      -->
+      <plugin>
+        <groupId>org.apache.maven.plugins</groupId>
+        <artifactId>maven-surefire-plugin</artifactId>
+        <version>${version.maven-surefire-plugin}</version>
+        <configuration>
+          <forkMode>always</forkMode>
+        </configuration>
+      </plugin>
+    </plugins>
+  </build>
+</project>

--- a/instrument-starters/opentracing-spring-cloud-kafka-starter/pom.xml
+++ b/instrument-starters/opentracing-spring-cloud-kafka-starter/pom.xml
@@ -42,6 +42,22 @@
     <dependency>
       <groupId>io.opentracing.contrib</groupId>
       <artifactId>opentracing-kafka-spring</artifactId>
+      <exclusions>
+        <exclusion>
+          <artifactId>*</artifactId>
+          <groupId>*</groupId>
+        </exclusion>
+      </exclusions>
+    </dependency>
+    <dependency>
+      <groupId>io.opentracing.contrib</groupId>
+      <artifactId>opentracing-kafka-client</artifactId>
+      <exclusions>
+        <exclusion>
+          <artifactId>*</artifactId>
+          <groupId>*</groupId>
+        </exclusion>
+      </exclusions>
     </dependency>
 
     <dependency>

--- a/instrument-starters/opentracing-spring-cloud-kafka-starter/src/main/java/io/opentracing/contrib/spring/cloud/kafka/KafkaAutoConfiguration.java
+++ b/instrument-starters/opentracing-spring-cloud-kafka-starter/src/main/java/io/opentracing/contrib/spring/cloud/kafka/KafkaAutoConfiguration.java
@@ -1,0 +1,73 @@
+/**
+ * Copyright 2017-2020 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.contrib.spring.cloud.kafka;
+
+import io.opentracing.Tracer;
+import io.opentracing.contrib.kafka.spring.TracingConsumerFactory;
+import io.opentracing.contrib.kafka.spring.TracingProducerFactory;
+import io.opentracing.contrib.spring.tracer.configuration.TracerAutoConfiguration;
+import org.springframework.beans.BeansException;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.boot.autoconfigure.AutoConfigureAfter;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.ProducerFactory;
+
+@Configuration
+@ConditionalOnClass(ProducerFactory.class)
+@ConditionalOnBean(Tracer.class)
+@AutoConfigureAfter(TracerAutoConfiguration.class)
+@ConditionalOnProperty(name = "opentracing.spring.cloud.kafka.enabled", havingValue = "true", matchIfMissing = true)
+class KafkaAutoConfiguration {
+
+  @Bean
+  public BeanPostProcessor kafkaProducerPostProcessor(Tracer tracer) {
+    return new BeanPostProcessor() {
+      @Override
+      public Object postProcessBeforeInitialization(Object bean, String beanName) throws BeansException {
+        return bean;
+      }
+
+      @Override
+      public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
+        if (bean instanceof ProducerFactory && !(bean instanceof TracingProducerFactory)) {
+          return new TracingProducerFactory((ProducerFactory)bean, tracer);
+        }
+        return bean;
+      }
+    };
+  }
+
+  @Bean
+  public BeanPostProcessor kafkaConsumerPostProcessor(Tracer tracer) {
+    return new BeanPostProcessor() {
+      @Override
+      public Object postProcessBeforeInitialization(Object bean, String beanName) throws BeansException {
+        return bean;
+      }
+
+      @Override
+      public Object postProcessAfterInitialization(Object bean, String beanName) throws BeansException {
+        if (bean instanceof ConsumerFactory && !(bean instanceof TracingConsumerFactory)) {
+          return new TracingConsumerFactory((ConsumerFactory) bean, tracer);
+        }
+        return bean;
+      }
+    };
+  }
+}

--- a/instrument-starters/opentracing-spring-cloud-kafka-starter/src/main/resources/META-INF/additional-spring-configuration-metadata.json
+++ b/instrument-starters/opentracing-spring-cloud-kafka-starter/src/main/resources/META-INF/additional-spring-configuration-metadata.json
@@ -1,0 +1,10 @@
+{
+  "properties": [
+    {
+      "name": "opentracing.spring.cloud.kafka.enabled",
+      "type": "java.lang.Boolean",
+      "description": "Enable Kafka tracing.",
+      "defaultValue": true
+    }
+  ]
+}

--- a/instrument-starters/opentracing-spring-cloud-kafka-starter/src/main/resources/META-INF/spring.factories
+++ b/instrument-starters/opentracing-spring-cloud-kafka-starter/src/main/resources/META-INF/spring.factories
@@ -1,0 +1,2 @@
+org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
+io.opentracing.contrib.spring.cloud.kafka.KafkaAutoConfiguration

--- a/instrument-starters/opentracing-spring-cloud-kafka-starter/src/test/java/io/opentracing/contrib/spring/cloud/kafka/KafkaAutoConfigurationTest.java
+++ b/instrument-starters/opentracing-spring-cloud-kafka-starter/src/test/java/io/opentracing/contrib/spring/cloud/kafka/KafkaAutoConfigurationTest.java
@@ -1,0 +1,159 @@
+/**
+ * Copyright 2017-2020 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.contrib.spring.cloud.kafka;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.mock;
+
+import io.opentracing.Tracer;
+import io.opentracing.contrib.kafka.spring.TracingConsumerFactory;
+import io.opentracing.contrib.kafka.spring.TracingProducerFactory;
+import java.util.Map;
+import java.util.Properties;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.producer.Producer;
+import org.apache.kafka.common.serialization.Deserializer;
+import org.junit.Test;
+import org.springframework.boot.test.util.TestPropertyValues;
+import org.springframework.context.annotation.AnnotationConfigApplicationContext;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+import org.springframework.kafka.core.ConsumerFactory;
+import org.springframework.kafka.core.ProducerFactory;
+
+public class KafkaAutoConfigurationTest {
+
+  @Test
+  public void loadKafkaTracingProducerFactory() {
+    AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
+    context.register(TracerConfig.class, FakeKafkaConfig.class, KafkaAutoConfiguration.class);
+    context.refresh();
+    ProducerFactory tracingProducerFactory = context.getBean(ProducerFactory.class);
+    assertTrue(tracingProducerFactory instanceof TracingProducerFactory);
+  }
+
+  @Test
+  public void loadNormalProducerFactoryWhenDisabled() {
+    AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
+    context.register(TracerConfig.class, FakeKafkaConfig.class, KafkaAutoConfiguration.class);
+    TestPropertyValues.of("opentracing.spring.cloud.kafka.enabled:false").applyTo(context);
+    context.refresh();
+    ProducerFactory tracingProducerFactory = context.getBean(ProducerFactory.class);
+    assertFalse(tracingProducerFactory instanceof TracingProducerFactory);
+  }
+
+  @Test
+  public void loadTracingConsumerFactory() {
+    AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
+    context.register(TracerConfig.class, FakeKafkaConfig.class, KafkaAutoConfiguration.class);
+    context.refresh();
+    ConsumerFactory tracingConsumerFactory = context.getBean(ConsumerFactory.class);
+    assertTrue(tracingConsumerFactory instanceof TracingConsumerFactory);
+  }
+
+  @Test
+  public void loadNormalConsumerFactoryWhenDisabled() {
+    AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
+    context.register(TracerConfig.class, FakeKafkaConfig.class, KafkaAutoConfiguration.class);
+    TestPropertyValues.of("opentracing.spring.cloud.kafka.enabled:false").applyTo(context);
+    context.refresh();
+    ConsumerFactory consumerFactory = context.getBean(ConsumerFactory.class);
+    assertFalse(consumerFactory instanceof TracingConsumerFactory);
+  }
+
+  @Test
+  public void loadNormalConsumerFactoryWhenTracerNotPresent() {
+    AnnotationConfigApplicationContext context = new AnnotationConfigApplicationContext();
+    context.register(FakeKafkaConfig.class, KafkaAutoConfiguration.class);
+    context.refresh();
+    ConsumerFactory consumerFactory = context.getBean(ConsumerFactory.class);
+    assertFalse(consumerFactory instanceof TracingConsumerFactory);
+  }
+
+
+
+
+  @Configuration
+  static class TracerConfig {
+
+    @Bean
+    public Tracer tracer() {
+      return mock(Tracer.class);
+    }
+  }
+
+  static class FakeKafkaConfig {
+
+    @Bean
+    public ProducerFactory<String, String> producerFactory() {
+      return new ProducerFactory<String, String>() {
+        @Override
+        public Producer<String, String> createProducer() {
+          return null;
+        }
+      };
+    }
+
+    @Bean
+    public ConsumerFactory<String, String> consumerFactory() {
+      return new ConsumerFactory<String, String>() {
+        @Override
+        public Consumer<String, String> createConsumer() {
+          return null;
+        }
+
+        @Override
+        public Consumer<String, String> createConsumer(String clientIdSuffix) {
+          return null;
+        }
+
+        @Override
+        public Consumer<String, String> createConsumer(String groupId, String clientIdSuffix) {
+          return null;
+        }
+
+        @Override
+        public Consumer<String, String> createConsumer(String s, String s1, String s2) {
+          return null;
+        }
+
+        @Override
+        public Consumer<String, String> createConsumer(String groupId, String clientIdPrefix, String clientIdSuffix, Properties properties) {
+          return null;
+        }
+
+        @Override
+        public boolean isAutoCommit() {
+          return false;
+        }
+
+        @Override
+        public Map<String, Object> getConfigurationProperties() {
+          return null;
+        }
+
+        @Override
+        public Deserializer<String> getKeyDeserializer() {
+          return null;
+        }
+
+        @Override
+        public Deserializer<String> getValueDeserializer() {
+          return null;
+        }
+      };
+    }
+  }
+}

--- a/opentracing-spring-cloud-starter/pom.xml
+++ b/opentracing-spring-cloud-starter/pom.xml
@@ -56,6 +56,10 @@
     </dependency>
     <dependency>
       <groupId>${project.groupId}</groupId>
+      <artifactId>opentracing-spring-cloud-kafka-starter</artifactId>
+    </dependency>
+    <dependency>
+      <groupId>${project.groupId}</groupId>
       <artifactId>opentracing-spring-cloud-feign-starter</artifactId>
     </dependency>
     <dependency>

--- a/opentracing-spring-cloud-starter/src/test/java/io/opentracing/contrib/spring/cloud/NoDepsTest.java
+++ b/opentracing-spring-cloud-starter/src/test/java/io/opentracing/contrib/spring/cloud/NoDepsTest.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2018 The OpenTracing Authors
+ * Copyright 2017-2020 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -74,5 +74,10 @@ public class NoDepsTest {
   @Test(expected = ClassNotFoundException.class)
   public void testNoMongoClient() throws ClassNotFoundException {
     this.getClass().getClassLoader().loadClass("com.mongodb.MongoClient");
+  }
+
+  @Test(expected = ClassNotFoundException.class)
+  public void testNoKafkaProducer() throws ClassNotFoundException {
+    this.getClass().getClassLoader().loadClass("org.apache.kafka.clients.producer.KafkaProducer");
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -25,6 +25,7 @@
     <module>/instrument-starters/opentracing-spring-cloud-core</module>
     <module>instrument-starters/opentracing-spring-cloud-jdbc-starter</module>
     <module>instrument-starters/opentracing-spring-cloud-jms-starter</module>
+    <module>instrument-starters/opentracing-spring-cloud-kafka-starter</module>
     <module>instrument-starters/opentracing-spring-cloud-feign-starter</module>
     <module>instrument-starters/opentracing-spring-cloud-mongo-starter</module>
     <module>instrument-starters/opentracing-spring-cloud-websocket-starter</module>
@@ -87,6 +88,7 @@
     <version.io.opentracing.contrib-opentracing-spring-mongo>0.1.5</version.io.opentracing.contrib-opentracing-spring-mongo>
     <version.io.github.openfeign-feign-okhttp>10.2.0</version.io.github.openfeign-feign-okhttp>
     <version.io.github.openfeign.opentracing>0.4.0</version.io.github.openfeign.opentracing>
+    <version.io.opentracing.contrib-opentracing-kafka-spring>0.1.12</version.io.opentracing.contrib-opentracing-kafka-spring>
     <!-- spring-boot-starter-parent is a module of spring-boot-dependencies
         https://github.com/spring-projects/spring-boot/blob/master/spring-boot-starters/spring-boot-starter-parent/pom.xml -->
     <version.org.springframework.boot>2.2.0.RELEASE</version.org.springframework.boot>
@@ -132,6 +134,11 @@
       <dependency>
         <groupId>${project.groupId}</groupId>
         <artifactId>opentracing-spring-cloud-jms-starter</artifactId>
+        <version>${project.version}</version>
+      </dependency>
+      <dependency>
+        <groupId>${project.groupId}</groupId>
+        <artifactId>opentracing-spring-cloud-kafka-starter</artifactId>
         <version>${project.version}</version>
       </dependency>
       <dependency>
@@ -215,6 +222,11 @@
         <groupId>io.opentracing.contrib</groupId>
         <artifactId>opentracing-jms-2</artifactId>
         <version>${version.io.opentracing.contrib-opentracing-spring-jms}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.opentracing.contrib</groupId>
+        <artifactId>opentracing-kafka-spring</artifactId>
+        <version>${version.io.opentracing.contrib-opentracing-kafka-spring}</version>
       </dependency>
       <dependency>
         <groupId>io.opentracing.contrib</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -230,6 +230,11 @@
       </dependency>
       <dependency>
         <groupId>io.opentracing.contrib</groupId>
+        <artifactId>opentracing-kafka-client</artifactId>
+        <version>${version.io.opentracing.contrib-opentracing-kafka-spring}</version>
+      </dependency>
+      <dependency>
+        <groupId>io.opentracing.contrib</groupId>
         <artifactId>opentracing-spring-tracer-configuration-starter</artifactId>
         <version>${version.io.opentracing.contrib-opentracing-spring-tracer-configuration-starter}</version>
       </dependency>


### PR DESCRIPTION
This PR adds a starter for users of Spring Kafka.

The starter will, if enabled, wrap beans with the appropriate tracing counterparts from opentracing-contrib/java-kafka-client. 

This allows users of this library to get instrumentation of messages produced/consumed by Spring Kafka without any extra code or configuration.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opentracing-contrib/java-spring-cloud/280)
<!-- Reviewable:end -->
