### PR TITLE
Update opentracing-spring-tracer-configuration-starter to latest version

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -74,7 +74,7 @@
     <main.basedir>${project.basedir}</main.basedir>
 
     <version.io.opentracing>0.33.0</version.io.opentracing>
-    <version.io.opentracing.contrib-opentracing-spring-tracer-configuration-starter>0.2.0</version.io.opentracing.contrib-opentracing-spring-tracer-configuration-starter>
+    <version.io.opentracing.contrib-opentracing-spring-tracer-configuration-starter>0.3.1</version.io.opentracing.contrib-opentracing-spring-tracer-configuration-starter>
     <version.io.opentracing.contrib-opentracing-spring-web>3.0.1</version.io.opentracing.contrib-opentracing-spring-web>
     <version.io.opentracing.contrib-opentracing-spring-jms>0.1.7</version.io.opentracing.contrib-opentracing-spring-jms>
     <version.io.opentracing.contrib-opentracing-spring-messaging>1.0.0</version.io.opentracing.contrib-opentracing-spring-messaging>


### PR DESCRIPTION
This PR updates opentracing-spring-tracer-configuration-starter to 0.3.1, which is the latest version and is built against 0.33.0. This mitigates #283 at the moment, but does not solve the problem of dependencies being pulled in from this library.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/opentracing-contrib/java-spring-cloud/284)
<!-- Reviewable:end -->
