### PR TITLE
Support propagating trace context to callback

### DIFF
--- a/instrument-starters/opentracing-spring-cloud-core/src/main/java/io/opentracing/contrib/spring/cloud/async/instrument/TracedListenableFuture.java
+++ b/instrument-starters/opentracing-spring-cloud-core/src/main/java/io/opentracing/contrib/spring/cloud/async/instrument/TracedListenableFuture.java
@@ -1,0 +1,86 @@
+/**
+ * Copyright 2017-2020 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.contrib.spring.cloud.async.instrument;
+
+import io.opentracing.Span;
+import io.opentracing.Tracer;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
+
+import org.springframework.util.concurrent.FailureCallback;
+import org.springframework.util.concurrent.ListenableFuture;
+import org.springframework.util.concurrent.ListenableFutureCallback;
+import org.springframework.util.concurrent.SuccessCallback;
+
+/**
+ * @author MiNG
+ */
+public class TracedListenableFuture<T> implements ListenableFuture<T> {
+
+  private final ListenableFuture<T> delegate;
+  private final Tracer tracer;
+  private final Span span;
+
+  public TracedListenableFuture(ListenableFuture<T> delegate, Tracer tracer) {
+    this(delegate, tracer, tracer.activeSpan());
+  }
+
+  public TracedListenableFuture(ListenableFuture<T> delegate, Tracer tracer, Span span) {
+    this.delegate = delegate;
+    this.tracer = tracer;
+    this.span = span;
+  }
+
+  @Override
+  public void addCallback(ListenableFutureCallback<? super T> callback) {
+    delegate.addCallback(new TracedListenableFutureCallback<>(callback, tracer, span));
+  }
+
+  @Override
+  public void addCallback(SuccessCallback<? super T> successCallback, FailureCallback failureCallback) {
+    delegate.addCallback(new TracedListenableFutureCallback<>(successCallback, failureCallback, tracer, span));
+  }
+
+  @Override
+  public CompletableFuture<T> completable() {
+    return delegate.completable();
+  }
+
+  @Override
+  public boolean cancel(boolean mayInterruptIfRunning) {
+    return delegate.cancel(mayInterruptIfRunning);
+  }
+
+  @Override
+  public boolean isCancelled() {
+    return delegate.isCancelled();
+  }
+
+  @Override
+  public boolean isDone() {
+    return delegate.isDone();
+  }
+
+  @Override
+  public T get() throws InterruptedException, ExecutionException {
+    return delegate.get();
+  }
+
+  @Override
+  public T get(long timeout, TimeUnit unit) throws InterruptedException, ExecutionException, TimeoutException {
+    return delegate.get(timeout, unit);
+  }
+}

--- a/instrument-starters/opentracing-spring-cloud-core/src/main/java/io/opentracing/contrib/spring/cloud/async/instrument/TracedListenableFuture.java
+++ b/instrument-starters/opentracing-spring-cloud-core/src/main/java/io/opentracing/contrib/spring/cloud/async/instrument/TracedListenableFuture.java
@@ -35,18 +35,14 @@ public class TracedListenableFuture<T> implements ListenableFuture<T> {
   private final Span span;
 
   public TracedListenableFuture(ListenableFuture<T> delegate, Tracer tracer) {
-    this(delegate, tracer, tracer.activeSpan());
-  }
-
-  public TracedListenableFuture(ListenableFuture<T> delegate, Tracer tracer, Span span) {
     this.delegate = delegate;
     this.tracer = tracer;
-    this.span = span;
+    this.span = tracer.activeSpan();
   }
 
   @Override
   public void addCallback(ListenableFutureCallback<? super T> callback) {
-    delegate.addCallback(new TracedListenableFutureCallback<>(callback, tracer, span));
+    delegate.addCallback(new TracedListenableFutureCallback<>(callback, tracer));
   }
 
   @Override

--- a/instrument-starters/opentracing-spring-cloud-core/src/main/java/io/opentracing/contrib/spring/cloud/async/instrument/TracedListenableFuture.java
+++ b/instrument-starters/opentracing-spring-cloud-core/src/main/java/io/opentracing/contrib/spring/cloud/async/instrument/TracedListenableFuture.java
@@ -42,7 +42,7 @@ public class TracedListenableFuture<T> implements ListenableFuture<T> {
 
   @Override
   public void addCallback(ListenableFutureCallback<? super T> callback) {
-    delegate.addCallback(new TracedListenableFutureCallback<>(callback, tracer));
+    delegate.addCallback(new TracedListenableFutureCallback<>(callback, tracer, span));
   }
 
   @Override

--- a/instrument-starters/opentracing-spring-cloud-core/src/main/java/io/opentracing/contrib/spring/cloud/async/instrument/TracedListenableFutureCallback.java
+++ b/instrument-starters/opentracing-spring-cloud-core/src/main/java/io/opentracing/contrib/spring/cloud/async/instrument/TracedListenableFutureCallback.java
@@ -44,7 +44,7 @@ public class TracedListenableFutureCallback<T> implements ListenableFutureCallba
     this(successDelegate, failureDelegate, tracer, tracer.activeSpan());
   }
 
-  public TracedListenableFutureCallback(@Nullable SuccessCallback<T> successDelegate, @Nullable FailureCallback failureDelegate, Tracer tracer, Span span) {
+  public TracedListenableFutureCallback(SuccessCallback<T> successDelegate, FailureCallback failureDelegate, Tracer tracer, Span span) {
     Assert.notNull(successDelegate, "'successDelegate' must not be null");
     Assert.notNull(failureDelegate, "'failureDelegate' must not be null");
     this.successDelegate = successDelegate;

--- a/instrument-starters/opentracing-spring-cloud-core/src/main/java/io/opentracing/contrib/spring/cloud/async/instrument/TracedListenableFutureCallback.java
+++ b/instrument-starters/opentracing-spring-cloud-core/src/main/java/io/opentracing/contrib/spring/cloud/async/instrument/TracedListenableFutureCallback.java
@@ -1,0 +1,69 @@
+/**
+ * Copyright 2017-2020 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.contrib.spring.cloud.async.instrument;
+
+import io.opentracing.Scope;
+import io.opentracing.Span;
+import io.opentracing.Tracer;
+import org.springframework.lang.Nullable;
+import org.springframework.util.Assert;
+import org.springframework.util.concurrent.FailureCallback;
+import org.springframework.util.concurrent.ListenableFutureCallback;
+import org.springframework.util.concurrent.SuccessCallback;
+
+/**
+ * @author MiNG
+ */
+public class TracedListenableFutureCallback<T> implements ListenableFutureCallback<T> {
+
+  private final SuccessCallback<T> successDelegate;
+  private final FailureCallback failureDelegate;
+  private final Tracer tracer;
+  private final Span span;
+
+  public TracedListenableFutureCallback(ListenableFutureCallback<T> delegate, Tracer tracer) {
+    this(delegate, delegate, tracer, tracer.activeSpan());
+  }
+
+  public TracedListenableFutureCallback(ListenableFutureCallback<T> delegate, Tracer tracer, Span span) {
+    this(delegate, delegate, tracer, span);
+  }
+
+  public TracedListenableFutureCallback(SuccessCallback<T> successDelegate, FailureCallback failureDelegate, Tracer tracer) {
+    this(successDelegate, failureDelegate, tracer, tracer.activeSpan());
+  }
+
+  public TracedListenableFutureCallback(@Nullable SuccessCallback<T> successDelegate, @Nullable FailureCallback failureDelegate, Tracer tracer, Span span) {
+    Assert.notNull(successDelegate, "'successDelegate' must not be null");
+    Assert.notNull(failureDelegate, "'failureDelegate' must not be null");
+    this.successDelegate = successDelegate;
+    this.failureDelegate = failureDelegate;
+    this.tracer = tracer;
+    this.span = span;
+  }
+
+  @Override
+  public void onSuccess(T result) {
+    try (Scope ignored = span == null ? null : tracer.scopeManager().activate(span)) {
+      successDelegate.onSuccess(result);
+    }
+  }
+
+  @Override
+  public void onFailure(Throwable ex) {
+    try (Scope ignored = span == null ? null : tracer.scopeManager().activate(span)) {
+      failureDelegate.onFailure(ex);
+    }
+  }
+}

--- a/instrument-starters/opentracing-spring-cloud-core/src/main/java/io/opentracing/contrib/spring/cloud/async/instrument/TracedThreadPoolTaskExecutor.java
+++ b/instrument-starters/opentracing-spring-cloud-core/src/main/java/io/opentracing/contrib/spring/cloud/async/instrument/TracedThreadPoolTaskExecutor.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2019 The OpenTracing Authors
+ * Copyright 2017-2020 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -59,12 +59,12 @@ public class TracedThreadPoolTaskExecutor extends ThreadPoolTaskExecutor {
 
   @Override
   public ListenableFuture<?> submitListenable(Runnable task) {
-    return this.delegate.submitListenable(new TracedRunnable(task, tracer));
+    return new TracedListenableFuture<>(this.delegate.submitListenable(new TracedRunnable(task, tracer)), tracer);
   }
 
   @Override
   public <T> ListenableFuture<T> submitListenable(Callable<T> task) {
-    return this.delegate.submitListenable(new TracedCallable<>(task, tracer));
+    return new TracedListenableFuture<>(this.delegate.submitListenable(new TracedCallable<>(task, tracer)), tracer);
   }
 
   @Override

--- a/instrument-starters/opentracing-spring-cloud-core/src/main/java/io/opentracing/contrib/spring/cloud/async/instrument/TracedThreadPoolTaskScheduler.java
+++ b/instrument-starters/opentracing-spring-cloud-core/src/main/java/io/opentracing/contrib/spring/cloud/async/instrument/TracedThreadPoolTaskScheduler.java
@@ -1,5 +1,5 @@
 /**
- * Copyright 2017-2019 The OpenTracing Authors
+ * Copyright 2017-2020 The OpenTracing Authors
  *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
@@ -26,6 +26,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ScheduledThreadPoolExecutor;
 import java.util.concurrent.ThreadFactory;
+
 import org.springframework.lang.Nullable;
 import org.springframework.scheduling.Trigger;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
@@ -113,12 +114,12 @@ public class TracedThreadPoolTaskScheduler
 
   @Override
   public ListenableFuture<?> submitListenable(Runnable task) {
-    return delegate.submitListenable(new TracedRunnable(task, tracer));
+    return new TracedListenableFuture<>(delegate.submitListenable(new TracedRunnable(task, tracer)), tracer);
   }
 
   @Override
   public <T> ListenableFuture<T> submitListenable(Callable<T> task) {
-    return delegate.submitListenable(new TracedCallable<>(task, tracer));
+    return new TracedListenableFuture<>(delegate.submitListenable(new TracedCallable<>(task, tracer)), tracer);
   }
 
   @Override

--- a/instrument-starters/opentracing-spring-cloud-core/src/test/java/io/opentracing/contrib/spring/cloud/async/instrument/TracedListenableFutureTest.java
+++ b/instrument-starters/opentracing-spring-cloud-core/src/test/java/io/opentracing/contrib/spring/cloud/async/instrument/TracedListenableFutureTest.java
@@ -1,0 +1,258 @@
+/**
+ * Copyright 2017-2020 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.contrib.spring.cloud.async.instrument;
+
+import io.opentracing.Scope;
+import io.opentracing.Span;
+import io.opentracing.mock.MockTracer;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.locks.LockSupport;
+
+import org.junit.AfterClass;
+import org.junit.Assert;
+import org.junit.Test;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler;
+import org.springframework.util.concurrent.ListenableFuture;
+
+/**
+ * Tests for {@link TracedListenableFuture}, to ensure context is propagated to all callbacks.
+ *
+ * @author MiNG
+ */
+public class TracedListenableFutureTest {
+
+  private static final MockTracer TRACER = new MockTracer();
+  private static final TracedThreadPoolTaskExecutor EXECUTOR;
+  static {
+    final ThreadPoolTaskExecutor delegate = new ThreadPoolTaskExecutor();
+    delegate.initialize();
+    EXECUTOR = new TracedThreadPoolTaskExecutor(TRACER, delegate);
+  }
+  private static final TracedThreadPoolTaskScheduler SCHEDULER;
+  static {
+    final ThreadPoolTaskScheduler delegate = new ThreadPoolTaskScheduler();
+    delegate.initialize();
+    SCHEDULER = new TracedThreadPoolTaskScheduler(TRACER, delegate);
+  }
+
+  @AfterClass
+  public static void cleanup() {
+    EXECUTOR.destroy();
+    SCHEDULER.destroy();
+    TRACER.close();
+  }
+
+  @Test(timeout = 1000)
+  public void executor_submitListenable_runnable_onSuccess() throws Exception {
+    final Span span = TRACER.buildSpan("executor_submitListenable_runnable_onSuccess").start();
+    try (Scope ignored = TRACER.activateSpan(span)) {
+      final ListenableFuture<?> listenableFuture = EXECUTOR.submitListenable(() -> {
+        // Force callback run in thread pool
+        LockSupport.parkNanos(100_000_000);
+        Assert.assertSame(span, TRACER.activeSpan());
+      });
+      final CompletableFuture<Boolean> callbackResult = new CompletableFuture<>();
+      listenableFuture.addCallback(
+          r -> callbackResult.complete(span == TRACER.activeSpan()),
+          e -> { /* NOOP */ }
+      );
+      listenableFuture.get();
+      Assert.assertTrue(callbackResult.get());
+    }
+  }
+
+  @Test(timeout = 1000)
+  public void executor_submitListenable_callable_onSuccess() throws Exception {
+    final Span span = TRACER.buildSpan("executor_submitListenable_callable_onSuccess").start();
+    try (Scope ignored = TRACER.activateSpan(span)) {
+      final ListenableFuture<?> listenableFuture = EXECUTOR.submitListenable(() -> {
+        // Force callback run in thread pool
+        LockSupport.parkNanos(100_000_000);
+        Assert.assertSame(span, TRACER.activeSpan());
+        return null;
+      });
+      final CompletableFuture<Boolean> callbackResult = new CompletableFuture<>();
+      listenableFuture.addCallback(
+          r -> callbackResult.complete(span == TRACER.activeSpan()),
+          e -> { /* NOOP */ }
+      );
+      listenableFuture.get();
+      Assert.assertTrue(callbackResult.get());
+    }
+  }
+
+  @Test(timeout = 1000)
+  public void executor_submitListenable_runnable_onFailure() throws Exception {
+    final Span span = TRACER.buildSpan("executor_submitListenable_runnable_onFailure").start();
+    try (Scope ignored = TRACER.activateSpan(span)) {
+      final ListenableFuture<?> listenableFuture = EXECUTOR.submitListenable(() -> {
+        // Force callback run in thread pool
+        LockSupport.parkNanos(100_000_000);
+        Assert.assertSame(span, TRACER.activeSpan());
+        throw new Exception();
+      });
+      final CompletableFuture<Boolean> callbackResult = new CompletableFuture<>();
+      listenableFuture.addCallback(
+          r -> { /* NOOP */ },
+          e -> {
+            if (e instanceof AssertionError) {
+              callbackResult.completeExceptionally(e);
+            } else {
+              callbackResult.complete(span == TRACER.activeSpan());
+            }
+          }
+      );
+      try {
+        listenableFuture.get();
+        Assert.fail();
+      } catch (Exception e) {
+        // success
+      }
+      Assert.assertTrue(callbackResult.get());
+    }
+  }
+
+  @Test(timeout = 1000)
+  public void executor_submitListenable_callable_onFailure() throws Exception {
+    final Span span = TRACER.buildSpan("executor_submitListenable_callable_onFailure").start();
+    try (Scope ignored = TRACER.activateSpan(span)) {
+      final ListenableFuture<?> listenableFuture = EXECUTOR.submitListenable(() -> {
+        // Force callback run in thread pool
+        LockSupport.parkNanos(100_000_000);
+        Assert.assertSame(span, TRACER.activeSpan());
+        throw new Exception();
+      });
+      final CompletableFuture<Boolean> callbackResult = new CompletableFuture<>();
+      listenableFuture.addCallback(
+          r -> { /* NOOP */ },
+          e -> {
+            if (e instanceof AssertionError) {
+              callbackResult.completeExceptionally(e);
+            } else {
+              callbackResult.complete(span == TRACER.activeSpan());
+            }
+          }
+      );
+      try {
+        listenableFuture.get();
+        Assert.fail();
+      } catch (Exception e) {
+        // success
+      }
+      Assert.assertTrue(callbackResult.get());
+    }
+  }
+
+  @Test(timeout = 1000)
+  public void scheduler_submitListenable_runnable_onSuccess() throws Exception {
+    final Span span = TRACER.buildSpan("executor_submitListenable_runnable_onSuccess").start();
+    try (Scope ignored = TRACER.activateSpan(span)) {
+      final ListenableFuture<?> listenableFuture = SCHEDULER.submitListenable(() -> {
+        // Force callback run in thread pool
+        LockSupport.parkNanos(100_000_000);
+        Assert.assertSame(span, TRACER.activeSpan());
+      });
+      final CompletableFuture<Boolean> callbackResult = new CompletableFuture<>();
+      listenableFuture.addCallback(
+          r -> callbackResult.complete(span == TRACER.activeSpan()),
+          e -> { /* NOOP */ }
+      );
+      listenableFuture.get();
+      Assert.assertTrue(callbackResult.get());
+    }
+  }
+
+  @Test(timeout = 1000)
+  public void scheduler_submitListenable_callable_onSuccess() throws Exception {
+    final Span span = TRACER.buildSpan("executor_submitListenable_callable_onSuccess").start();
+    try (Scope ignored = TRACER.activateSpan(span)) {
+      final ListenableFuture<?> listenableFuture = SCHEDULER.submitListenable(() -> {
+        // Force callback run in thread pool
+        LockSupport.parkNanos(100_000_000);
+        Assert.assertSame(span, TRACER.activeSpan());
+        return null;
+      });
+      final CompletableFuture<Boolean> callbackResult = new CompletableFuture<>();
+      listenableFuture.addCallback(
+          r -> callbackResult.complete(span == TRACER.activeSpan()),
+          e -> { /* NOOP */ }
+      );
+      listenableFuture.get();
+      Assert.assertTrue(callbackResult.get());
+    }
+  }
+
+  @Test(timeout = 1000)
+  public void scheduler_submitListenable_runnable_onFailure() throws Exception {
+    final Span span = TRACER.buildSpan("executor_submitListenable_runnable_onFailure").start();
+    try (Scope ignored = TRACER.activateSpan(span)) {
+      final ListenableFuture<?> listenableFuture = SCHEDULER.submitListenable(() -> {
+        // Force callback run in thread pool
+        LockSupport.parkNanos(100_000_000);
+        Assert.assertSame(span, TRACER.activeSpan());
+        throw new Exception();
+      });
+      final CompletableFuture<Boolean> callbackResult = new CompletableFuture<>();
+      listenableFuture.addCallback(
+          r -> { /* NOOP */ },
+          e -> {
+            if (e instanceof AssertionError) {
+              callbackResult.completeExceptionally(e);
+            } else {
+              callbackResult.complete(span == TRACER.activeSpan());
+            }
+          }
+      );
+      try {
+        listenableFuture.get();
+        Assert.fail();
+      } catch (Exception e) {
+        // success
+      }
+      Assert.assertTrue(callbackResult.get());
+    }
+  }
+
+  @Test(timeout = 1000)
+  public void scheduler_submitListenable_callable_onFailure() throws Exception {
+    final Span span = TRACER.buildSpan("executor_submitListenable_callable_onFailure").start();
+    try (Scope ignored = TRACER.activateSpan(span)) {
+      final ListenableFuture<?> listenableFuture = SCHEDULER.submitListenable(() -> {
+        // Force callback run in thread pool
+        LockSupport.parkNanos(100_000_000);
+        Assert.assertSame(span, TRACER.activeSpan());
+        throw new Exception();
+      });
+      final CompletableFuture<Boolean> callbackResult = new CompletableFuture<>();
+      listenableFuture.addCallback(
+          r -> { /* NOOP */ },
+          e -> {
+            if (e instanceof AssertionError) {
+              callbackResult.completeExceptionally(e);
+            } else {
+              callbackResult.complete(span == TRACER.activeSpan());
+            }
+          }
+      );
+      try {
+        listenableFuture.get();
+        Assert.fail();
+      } catch (Exception e) {
+        // success
+      }
+      Assert.assertTrue(callbackResult.get());
+    }
+  }
+}

--- a/instrument-starters/opentracing-spring-cloud-core/src/test/java/io/opentracing/contrib/spring/cloud/async/instrument/TracedListenableFutureTest.java
+++ b/instrument-starters/opentracing-spring-cloud-core/src/test/java/io/opentracing/contrib/spring/cloud/async/instrument/TracedListenableFutureTest.java
@@ -54,7 +54,7 @@ public class TracedListenableFutureTest {
     TRACER.close();
   }
 
-  @Test(timeout = 1000)
+  @Test
   public void executor_submitListenable_runnable_onSuccess() throws Exception {
     final Span span = TRACER.buildSpan("executor_submitListenable_runnable_onSuccess").start();
     try (Scope ignored = TRACER.activateSpan(span)) {
@@ -73,7 +73,7 @@ public class TracedListenableFutureTest {
     }
   }
 
-  @Test(timeout = 1000)
+  @Test
   public void executor_submitListenable_callable_onSuccess() throws Exception {
     final Span span = TRACER.buildSpan("executor_submitListenable_callable_onSuccess").start();
     try (Scope ignored = TRACER.activateSpan(span)) {
@@ -93,7 +93,7 @@ public class TracedListenableFutureTest {
     }
   }
 
-  @Test(timeout = 1000)
+  @Test
   public void executor_submitListenable_runnable_onFailure() throws Exception {
     final Span span = TRACER.buildSpan("executor_submitListenable_runnable_onFailure").start();
     try (Scope ignored = TRACER.activateSpan(span)) {
@@ -124,7 +124,7 @@ public class TracedListenableFutureTest {
     }
   }
 
-  @Test(timeout = 1000)
+  @Test
   public void executor_submitListenable_callable_onFailure() throws Exception {
     final Span span = TRACER.buildSpan("executor_submitListenable_callable_onFailure").start();
     try (Scope ignored = TRACER.activateSpan(span)) {
@@ -155,7 +155,7 @@ public class TracedListenableFutureTest {
     }
   }
 
-  @Test(timeout = 1000)
+  @Test
   public void scheduler_submitListenable_runnable_onSuccess() throws Exception {
     final Span span = TRACER.buildSpan("executor_submitListenable_runnable_onSuccess").start();
     try (Scope ignored = TRACER.activateSpan(span)) {
@@ -174,7 +174,7 @@ public class TracedListenableFutureTest {
     }
   }
 
-  @Test(timeout = 1000)
+  @Test
   public void scheduler_submitListenable_callable_onSuccess() throws Exception {
     final Span span = TRACER.buildSpan("executor_submitListenable_callable_onSuccess").start();
     try (Scope ignored = TRACER.activateSpan(span)) {
@@ -194,7 +194,7 @@ public class TracedListenableFutureTest {
     }
   }
 
-  @Test(timeout = 1000)
+  @Test
   public void scheduler_submitListenable_runnable_onFailure() throws Exception {
     final Span span = TRACER.buildSpan("executor_submitListenable_runnable_onFailure").start();
     try (Scope ignored = TRACER.activateSpan(span)) {
@@ -225,7 +225,7 @@ public class TracedListenableFutureTest {
     }
   }
 
-  @Test(timeout = 1000)
+  @Test
   public void scheduler_submitListenable_callable_onFailure() throws Exception {
     final Span span = TRACER.buildSpan("executor_submitListenable_callable_onFailure").start();
     try (Scope ignored = TRACER.activateSpan(span)) {


### PR DESCRIPTION
Implements #286 .

The `CompletableFuture` returned by `ListenableFuture.completable()` is not injected yet, because there is too much methods to be processed. And the injection to `CompletableFuture` should be feature of [java-concurrent](https://github.com/opentracing-contrib/java-concurrent) project. I'll open an issue for `CompletableFuture` injection in java-concurrent project.