### PR TITLE
Mayank:297_spring-webmvc

### DIFF
--- a/instrument-starters/opentracing-spring-cloud-gateway-starter/pom.xml
+++ b/instrument-starters/opentracing-spring-cloud-gateway-starter/pom.xml
@@ -37,7 +37,7 @@
 
     <dependency>
       <groupId>org.springframework</groupId>
-      <artifactId>spring-web</artifactId>
+      <artifactId>spring-webmvc</artifactId>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Resolves #279 

replacing `spring-web` with `spring-webmvc` in `opentracing-spring-cloud-gateway-starter` as per issue [297](https://github.com/opentracing-contrib/java-spring-cloud/issues/297)