### PR TITLE
Fix spring-web/wembvc dependency for opentracing-spring-cloud-gateway-starter

### DIFF
--- a/instrument-starters/opentracing-spring-cloud-gateway-starter/pom.xml
+++ b/instrument-starters/opentracing-spring-cloud-gateway-starter/pom.xml
@@ -37,7 +37,8 @@
 
     <dependency>
       <groupId>org.springframework</groupId>
-      <artifactId>spring-webmvc</artifactId>
+      <artifactId>spring-web</artifactId>
+      <optional>true</optional>
     </dependency>
 
     <dependency>


### PR DESCRIPTION
Ensure that the Spring Cloud Gateway instrumentation starter does not
pull in the incompatible spring-webmvc dependency. Mark the correct
spring-web dependency as optional, to avoid polluting downstream
classpath.

Fixes #297, amends #298