### PR TITLE
Add @Traced annotation

### DIFF
--- a/instrument-starters/opentracing-spring-cloud-aop/pom.xml
+++ b/instrument-starters/opentracing-spring-cloud-aop/pom.xml
@@ -1,0 +1,33 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+
+    Copyright 2017-2018 The OpenTracing Authors
+
+    Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+    in compliance with the License. You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing, software distributed under the License
+    is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+    or implied. See the License for the specific language governing permissions and limitations under
+    the License.
+
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+  <modelVersion>4.0.0</modelVersion>
+  <parent>
+    <groupId>io.opentracing.contrib</groupId>
+    <artifactId>opentracing-spring-cloud-parent</artifactId>
+    <version>0.5.8-SNAPSHOT</version>
+    <relativePath>../../</relativePath>
+  </parent>
+
+  <artifactId>opentracing-spring-cloud-aop</artifactId>
+
+  <properties>
+    <main.basedir>${project.basedir}/../../</main.basedir>
+  </properties>
+
+
+</project>

--- a/instrument-starters/opentracing-spring-cloud-aop/src/main/java/io/opentracing/contrib/spring/cloud/aop/Traced.java
+++ b/instrument-starters/opentracing-spring-cloud-aop/src/main/java/io/opentracing/contrib/spring/cloud/aop/Traced.java
@@ -1,0 +1,29 @@
+/**
+ * Copyright 2017-2018 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.contrib.spring.cloud.aop;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+@Target({ElementType.METHOD, ElementType.ANNOTATION_TYPE, ElementType.TYPE})
+@Retention(RetentionPolicy.RUNTIME)
+public @interface Traced {
+
+  String component() default "traced";
+
+  String operationName() default "";
+
+}

--- a/instrument-starters/opentracing-spring-cloud-core/pom.xml
+++ b/instrument-starters/opentracing-spring-cloud-core/pom.xml
@@ -30,6 +30,11 @@
   </properties>
 
   <dependencies>
+
+    <dependency>
+      <groupId>io.opentracing.contrib</groupId>
+      <artifactId>opentracing-spring-cloud-aop</artifactId>
+    </dependency>
     <dependency>
       <groupId>io.opentracing.contrib</groupId>
       <artifactId>opentracing-spring-tracer-configuration-starter</artifactId>
@@ -52,6 +57,12 @@
     <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-web</artifactId>
+      <optional>true</optional>
+    </dependency>
+    <dependency>
+      <groupId>io.opentracing.contrib</groupId>
+      <artifactId>opentracing-spring-web-starter</artifactId>
+      <version>${version.io.opentracing.contrib-opentracing-spring-web}</version>
       <optional>true</optional>
     </dependency>
 
@@ -85,9 +96,8 @@
       <scope>test</scope>
     </dependency>
     <dependency>
-      <groupId>io.opentracing.contrib</groupId>
-      <artifactId>opentracing-spring-web-starter</artifactId>
-      <version>${version.io.opentracing.contrib-opentracing-spring-web}</version>
+      <groupId>org.assertj</groupId>
+      <artifactId>assertj-core</artifactId>
       <scope>test</scope>
     </dependency>
   </dependencies>

--- a/instrument-starters/opentracing-spring-cloud-core/src/main/java/io/opentracing/contrib/spring/cloud/aop/AopTracingProperties.java
+++ b/instrument-starters/opentracing-spring-cloud-core/src/main/java/io/opentracing/contrib/spring/cloud/aop/AopTracingProperties.java
@@ -1,0 +1,34 @@
+/**
+ * Copyright 2017-2018 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.contrib.spring.cloud.aop;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+@ConfigurationProperties("opentracing.spring.cloud.aop")
+public class AopTracingProperties {
+
+  /**
+   * Enable tracing for {@link org.springframework.scheduling.annotation.Scheduled}
+   */
+  private boolean enabled = true;
+
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  public void setEnabled(boolean enabled) {
+    this.enabled = enabled;
+  }
+
+}

--- a/instrument-starters/opentracing-spring-cloud-core/src/main/java/io/opentracing/contrib/spring/cloud/aop/BaseTracingAspect.java
+++ b/instrument-starters/opentracing-spring-cloud-core/src/main/java/io/opentracing/contrib/spring/cloud/aop/BaseTracingAspect.java
@@ -1,0 +1,121 @@
+/**
+ * Copyright 2017-2018 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.contrib.spring.cloud.aop;
+
+import io.opentracing.Scope;
+import io.opentracing.Span;
+import io.opentracing.Tracer;
+import io.opentracing.contrib.spring.cloud.ExtensionTags;
+import io.opentracing.tag.Tags;
+import java.lang.annotation.Annotation;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public abstract class BaseTracingAspect {
+
+  private static final Logger log = LoggerFactory.getLogger(BaseTracingAspect.class);
+  private final Tracer tracer;
+  private final Class<? extends Annotation> annotation;
+  private final List<MethodInterceptorSpanDecorator> decorators;
+  private Pattern skipPattern;
+
+  public BaseTracingAspect(Tracer tracer, List<MethodInterceptorSpanDecorator> decorators,
+      Class<? extends Annotation> annotation, Pattern skipPattern) {
+    this.tracer = tracer;
+    this.decorators = decorators != null ? decorators : new ArrayList<>();
+    this.annotation = annotation;
+    this.skipPattern = skipPattern;
+  }
+
+  /**
+   * This method should be overridden to add the proper annotation and call {@link
+   * BaseTracingAspect#internalTrace(ProceedingJoinPoint)}
+   */
+  public abstract Object trace(ProceedingJoinPoint pjp) throws Throwable;
+
+  protected Object internalTrace(ProceedingJoinPoint pjp) throws Throwable {
+    if (skipPattern.matcher(pjp.getTarget().getClass().getName()).matches()) {
+      return pjp.proceed();
+    }
+
+    // operation name is method name
+    Span span = tracer.buildSpan(getOperationName(pjp))
+        .withTag(Tags.COMPONENT.getKey(), getComponent(pjp))
+        .withTag(ExtensionTags.CLASS_TAG.getKey(), pjp.getTarget().getClass().getSimpleName())
+        .withTag(ExtensionTags.METHOD_TAG.getKey(), pjp.getSignature().getName())
+        .start();
+
+    try {
+      try (Scope scope = tracer.activateSpan(span)) {
+        decoratePreProceed(pjp, span);
+        Object result = pjp.proceed();
+        decoratePostProceed(pjp, span, result);
+        return result;
+      }
+    } catch (Exception ex) {
+      decorateOnError(pjp, span, ex);
+      throw ex;
+    } finally {
+      span.finish();
+    }
+  }
+
+  protected void decoratePreProceed(ProceedingJoinPoint pjp, Span span) {
+    for (MethodInterceptorSpanDecorator spanDecorator : decorators) {
+      try {
+        spanDecorator.onPreProceed(pjp, span);
+      } catch (RuntimeException exDecorator) {
+        log.error("Exception during decorating span", exDecorator);
+      }
+    }
+  }
+
+  protected void decoratePostProceed(ProceedingJoinPoint pjp, Span span, Object result) {
+    for (MethodInterceptorSpanDecorator spanDecorator : decorators) {
+      try {
+        spanDecorator.onPostProceed(pjp, result, span);
+      } catch (RuntimeException exDecorator) {
+        log.error("Exception during decorating span", exDecorator);
+      }
+    }
+  }
+
+  protected void decorateOnError(ProceedingJoinPoint pjp, Span span, Exception ex) {
+    for (MethodInterceptorSpanDecorator spanDecorator : decorators) {
+      spanDecorator.onError(pjp, ex, span);
+    }
+  }
+
+  protected String getOperationName(ProceedingJoinPoint pjp) {
+    return ((MethodSignature) pjp.getSignature()).getMethod().getName();
+  }
+
+  protected String getComponent(ProceedingJoinPoint pjp) {
+    return annotation.getSimpleName().toLowerCase();
+  }
+
+  protected boolean shouldTrace(ProceedingJoinPoint pjp) {
+    return true;
+  }
+
+  protected Tracer getTracer() {
+    return this.tracer;
+  }
+
+}

--- a/instrument-starters/opentracing-spring-cloud-core/src/main/java/io/opentracing/contrib/spring/cloud/aop/MethodInterceptorSpanDecorator.java
+++ b/instrument-starters/opentracing-spring-cloud-core/src/main/java/io/opentracing/contrib/spring/cloud/aop/MethodInterceptorSpanDecorator.java
@@ -1,0 +1,77 @@
+/**
+ * Copyright 2017-2018 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.contrib.spring.cloud.aop;
+
+import io.opentracing.Span;
+import io.opentracing.contrib.spring.cloud.ExtensionTags;
+import io.opentracing.contrib.spring.cloud.SpanUtils;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.reflect.MethodSignature;
+
+public interface MethodInterceptorSpanDecorator {
+
+  /**
+   * Decorate span before invocation is done, e.g. before
+   * {@link ProceedingJoinPoint#proceed()}
+   * is called
+   *
+   * @param ProceedingJoinPoint pjp
+   * @param Object result
+   * @param span span
+   */
+  void onPreProceed(ProceedingJoinPoint pjp, Span span);
+
+  /**
+   * Decorate span after invocation is done, e.g. after
+   * {@link ProceedingJoinPoint#proceed()}
+   * is called
+   *
+   * @param ProceedingJoinPoint pjp
+   * @param Object result
+   * @param span span
+   */
+  void onPostProceed(ProceedingJoinPoint pjp, Object result, Span span);
+
+  /**
+   * Decorate span when exception is thrown during the invocation, e.g. during
+   * {@link ProceedingJoinPoint#proceed()}
+   * is processing.
+   *
+   * @param ProceedingJoinPoint pjp
+   * @param ex exception
+   * @param span span
+   */
+  void onError(ProceedingJoinPoint pjp, Exception ex, Span span);
+
+  /**
+   * This decorator adds set of standard tags to the span.
+   */
+  class StandardTags implements MethodInterceptorSpanDecorator {
+
+    @Override
+    public void onPreProceed(ProceedingJoinPoint pjp, Span span) {
+      ExtensionTags.CLASS_TAG.set(span, pjp.getTarget().getClass().getSimpleName());
+      ExtensionTags.METHOD_TAG.set(span, ((MethodSignature) pjp.getSignature()).getName());
+    }
+
+    @Override
+    public void onPostProceed(ProceedingJoinPoint pjp, Object result, Span span) {
+    }
+
+    @Override
+    public void onError(ProceedingJoinPoint pjp, Exception ex, Span span) {
+      SpanUtils.captureException(span, ex);
+    }
+  }
+}

--- a/instrument-starters/opentracing-spring-cloud-core/src/main/java/io/opentracing/contrib/spring/cloud/scheduled/ScheduledAspect.java
+++ b/instrument-starters/opentracing-spring-cloud-core/src/main/java/io/opentracing/contrib/spring/cloud/scheduled/ScheduledAspect.java
@@ -18,49 +18,30 @@ import io.opentracing.Span;
 import io.opentracing.Tracer;
 import io.opentracing.contrib.spring.cloud.ExtensionTags;
 import io.opentracing.contrib.spring.cloud.SpanUtils;
+import io.opentracing.contrib.spring.cloud.aop.BaseTracingAspect;
+import io.opentracing.contrib.spring.cloud.aop.MethodInterceptorSpanDecorator;
 import io.opentracing.tag.Tags;
+import java.util.List;
 import java.util.regex.Pattern;
 import org.aspectj.lang.ProceedingJoinPoint;
 import org.aspectj.lang.annotation.Around;
 import org.aspectj.lang.annotation.Aspect;
+import org.springframework.scheduling.annotation.Scheduled;
 
 /**
  * @author Pavol Loffay
  */
 @Aspect
-public class ScheduledAspect {
-
-  static final String COMPONENT_NAME = "scheduled";
+public class ScheduledAspect extends BaseTracingAspect {
 
   private Tracer tracer;
-  private Pattern skipPattern;
 
-  public ScheduledAspect(Tracer tracer, ScheduledTracingProperties scheduledTracingProperties) {
-    this.tracer = tracer;
-    this.skipPattern = Pattern.compile(scheduledTracingProperties.getSkipPattern());
+  public ScheduledAspect(Tracer tracer, ScheduledTracingProperties scheduledTracingProperties, List<MethodInterceptorSpanDecorator> decorators) {
+    super(tracer, decorators, Scheduled.class, Pattern.compile(scheduledTracingProperties.getSkipPattern()));
   }
 
   @Around("execution (@org.springframework.scheduling.annotation.Scheduled  * *.*(..))")
-  public Object traceBackgroundThread(final ProceedingJoinPoint pjp) throws Throwable {
-    if (skipPattern.matcher(pjp.getTarget().getClass().getName()).matches()) {
-      return pjp.proceed();
-    }
-
-    // operation name is method name
-    Span span = tracer.buildSpan(pjp.getSignature().getName())
-        .withTag(Tags.COMPONENT.getKey(), COMPONENT_NAME)
-        .withTag(ExtensionTags.CLASS_TAG.getKey(), pjp.getTarget().getClass().getSimpleName())
-        .withTag(ExtensionTags.METHOD_TAG.getKey(), pjp.getSignature().getName())
-        .start();
-    try {
-      try (Scope scope = tracer.activateSpan(span)) {
-        return pjp.proceed();
-      }
-    } catch (Exception ex) {
-      SpanUtils.captureException(span, ex);
-      throw ex;
-    } finally {
-      span.finish();
-    }
+  public Object trace(final ProceedingJoinPoint pjp) throws Throwable {
+    return this.internalTrace(pjp);
   }
 }

--- a/instrument-starters/opentracing-spring-cloud-core/src/main/java/io/opentracing/contrib/spring/cloud/traced/TracedAspect.java
+++ b/instrument-starters/opentracing-spring-cloud-core/src/main/java/io/opentracing/contrib/spring/cloud/traced/TracedAspect.java
@@ -1,0 +1,59 @@
+/**
+ * Copyright 2017-2018 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.contrib.spring.cloud.traced;
+
+import io.opentracing.Tracer;
+import io.opentracing.contrib.spring.cloud.aop.BaseTracingAspect;
+import io.opentracing.contrib.spring.cloud.aop.MethodInterceptorSpanDecorator;
+import io.opentracing.contrib.spring.cloud.aop.Traced;
+import java.util.List;
+import java.util.regex.Pattern;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.annotation.Around;
+import org.aspectj.lang.annotation.Aspect;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.springframework.core.annotation.AnnotationUtils;
+
+@Aspect
+public class TracedAspect extends BaseTracingAspect {
+
+  public TracedAspect(Tracer tracer, TracedTracingProperties tracedTracingProperties, List<MethodInterceptorSpanDecorator> decorators) {
+    super(tracer, decorators, Traced.class, Pattern.compile(tracedTracingProperties.getSkipPattern()));
+  }
+
+  private Traced findAnnotation(ProceedingJoinPoint pjp) {
+    return AnnotationUtils
+        .findAnnotation(((MethodSignature) pjp.getSignature()).getMethod(), Traced.class);
+  }
+
+  @Override
+  @Around("execution (@io.opentracing.contrib.spring.cloud.aop.Traced * *.*(..))")
+  public Object trace(ProceedingJoinPoint pjp) throws Throwable {
+    return super.internalTrace(pjp);
+  }
+
+  @Override
+  protected String getComponent(ProceedingJoinPoint pjp) {
+    return findAnnotation(pjp).component();
+  }
+
+  @Override
+  protected String getOperationName(ProceedingJoinPoint pjp) {
+    String operationName = findAnnotation(pjp).operationName();
+    if (operationName == null || "".equals(operationName)) {
+      operationName = super.getOperationName(pjp);
+    }
+    return operationName;
+  }
+}

--- a/instrument-starters/opentracing-spring-cloud-core/src/main/java/io/opentracing/contrib/spring/cloud/traced/TracedAutoConfiguration.java
+++ b/instrument-starters/opentracing-spring-cloud-core/src/main/java/io/opentracing/contrib/spring/cloud/traced/TracedAutoConfiguration.java
@@ -11,52 +11,57 @@
  * or implied. See the License for the specific language governing permissions and limitations under
  * the License.
  */
-package io.opentracing.contrib.spring.cloud.scheduled;
+package io.opentracing.contrib.spring.cloud.traced;
 
 import io.opentracing.Tracer;
-
 import io.opentracing.contrib.spring.cloud.aop.MethodInterceptorSpanDecorator;
 import io.opentracing.contrib.spring.tracer.configuration.TracerAutoConfiguration;
 import java.util.ArrayList;
 import java.util.List;
+import org.aspectj.lang.ProceedingJoinPoint;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnBean;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
+import org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication;
 import org.springframework.boot.context.properties.EnableConfigurationProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.core.annotation.AnnotationAwareOrderComparator;
 import org.springframework.util.CollectionUtils;
 
-/**
- * @author Pavol Loffay
- */
 @Configuration
 @ConditionalOnBean(Tracer.class)
 @AutoConfigureAfter(TracerAutoConfiguration.class)
-@ConditionalOnProperty(name = "opentracing.spring.cloud.scheduled.enabled", havingValue = "true", matchIfMissing = true)
-@EnableConfigurationProperties(ScheduledTracingProperties.class)
-public class ScheduledAutoConfiguration {
+@ConditionalOnProperty(name = "opentracing.spring.cloud.traced.enabled", havingValue = "true", matchIfMissing = true)
+@ConditionalOnWebApplication
+@ConditionalOnClass({ProceedingJoinPoint.class})
+@EnableConfigurationProperties(TracedTracingProperties.class)
+public class TracedAutoConfiguration {
 
   private final ObjectProvider<List<MethodInterceptorSpanDecorator>> methodInterceptorSpanDecorators;
 
-  public ScheduledAutoConfiguration(ObjectProvider<List<MethodInterceptorSpanDecorator>> methodInterceptorSpanDecorators) {
+  public TracedAutoConfiguration(ObjectProvider<List<MethodInterceptorSpanDecorator>> methodInterceptorSpanDecorators) {
     this.methodInterceptorSpanDecorators = methodInterceptorSpanDecorators;
   }
 
   @Bean
-  public ScheduledAspect scheduledAspect(Tracer tracer, ScheduledTracingProperties scheduledTracingProperties) {
+  @ConditionalOnMissingBean
+  public TracedAspect tracedAspect(Tracer tracer, TracedTracingProperties tracedTracingProperties) {
     List<MethodInterceptorSpanDecorator> spanDecorators = new ArrayList<>();
     spanDecorators.add(new MethodInterceptorSpanDecorator.StandardTags());
 
-    List<MethodInterceptorSpanDecorator> providedDecorators = this.methodInterceptorSpanDecorators.getIfAvailable();
-    if (!CollectionUtils.isEmpty(providedDecorators)) {
-      providedDecorators = new ArrayList<>(providedDecorators);
-      AnnotationAwareOrderComparator.sort(providedDecorators);
-      spanDecorators.addAll(providedDecorators);
+    List<MethodInterceptorSpanDecorator> decorators = this.methodInterceptorSpanDecorators
+        .getIfAvailable();
+    if (!CollectionUtils.isEmpty(decorators)) {
+      decorators = new ArrayList<>(decorators);
+      AnnotationAwareOrderComparator.sort(decorators);
+      spanDecorators.addAll(decorators);
     }
 
-    return new ScheduledAspect(tracer, scheduledTracingProperties, spanDecorators);
+    return new TracedAspect(tracer, tracedTracingProperties, spanDecorators);
   }
+
 }

--- a/instrument-starters/opentracing-spring-cloud-core/src/main/java/io/opentracing/contrib/spring/cloud/traced/TracedTracingProperties.java
+++ b/instrument-starters/opentracing-spring-cloud-core/src/main/java/io/opentracing/contrib/spring/cloud/traced/TracedTracingProperties.java
@@ -1,0 +1,49 @@
+/**
+ * Copyright 2017-2018 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.contrib.spring.cloud.traced;
+
+import org.springframework.boot.context.properties.ConfigurationProperties;
+
+/**
+ * @author Pavol Loffay
+ */
+@ConfigurationProperties("opentracing.spring.cloud.traced")
+public class TracedTracingProperties {
+
+  /**
+   * Enable tracing for {@link io.opentracing.contrib.spring.cloud.aop.Traced}
+   */
+  private boolean enabled = true;
+
+  /**
+   * Regex of fully qualified class name annotated with {@link io.opentracing.contrib.spring.cloud.aop.Traced}
+   */
+  private String skipPattern = "";
+
+  public boolean isEnabled() {
+    return enabled;
+  }
+
+  public void setEnabled(boolean enabled) {
+    this.enabled = enabled;
+  }
+
+  public String getSkipPattern() {
+    return skipPattern;
+  }
+
+  public void setSkipPattern(String skipPattern) {
+    this.skipPattern = skipPattern;
+  }
+}

--- a/instrument-starters/opentracing-spring-cloud-core/src/main/resources/META-INF/spring.factories
+++ b/instrument-starters/opentracing-spring-cloud-core/src/main/resources/META-INF/spring.factories
@@ -2,7 +2,8 @@ org.springframework.boot.autoconfigure.EnableAutoConfiguration=\
 io.opentracing.contrib.spring.cloud.async.CustomAsyncConfigurerAutoConfiguration,\
 io.opentracing.contrib.spring.cloud.async.DefaultAsyncAutoConfiguration,\
 io.opentracing.contrib.spring.cloud.scheduled.ScheduledAutoConfiguration,\
-io.opentracing.contrib.spring.cloud.log.LoggingAutoConfiguration
+io.opentracing.contrib.spring.cloud.log.LoggingAutoConfiguration,\
+io.opentracing.contrib.spring.cloud.traced.TracedAutoConfiguration
 
 # Environment Post Processor
 org.springframework.boot.env.EnvironmentPostProcessor=\

--- a/instrument-starters/opentracing-spring-cloud-core/src/test/java/io/opentracing/contrib/spring/cloud/aop/BaseTracingAspectTest.java
+++ b/instrument-starters/opentracing-spring-cloud-core/src/test/java/io/opentracing/contrib/spring/cloud/aop/BaseTracingAspectTest.java
@@ -1,0 +1,139 @@
+/**
+ * Copyright 2017-2018 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.contrib.spring.cloud.aop;
+
+import static org.mockito.Matchers.any;
+import static org.mockito.Matchers.same;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import io.opentracing.Span;
+import io.opentracing.Tracer;
+import io.opentracing.mock.MockTracer;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.assertj.core.api.ThrowableAssert;
+import org.assertj.core.api.WithAssertions;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Matchers;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+import org.springframework.stereotype.Component;
+
+@RunWith(MockitoJUnitRunner.class)
+public class BaseTracingAspectTest implements WithAssertions {
+
+  private MockTracer tracer = new MockTracer();
+  private List<MethodInterceptorSpanDecorator> decorators = new ArrayList<MethodInterceptorSpanDecorator>();
+  @Mock
+  private MethodInterceptorSpanDecorator decorator;
+  @Mock
+  private ProceedingJoinPoint pjp;
+  @Mock
+  private MethodSignature methodSignature;
+
+  private TestTracingAspect aspect;
+
+  private Method method;
+  @Mock
+  private Object result;
+
+  @Before
+  public void init() throws Throwable {
+    method = Object.class.getMethod("toString", (Class<?>[]) null);
+    aspect = new TestTracingAspect(tracer, decorators, Component.class);
+    decorators.add(decorator);
+    when(pjp.getSignature()).thenReturn(methodSignature);
+    when(methodSignature.getMethod()).thenReturn(method);
+    when(pjp.proceed()).thenReturn(result);
+    when(pjp.getTarget()).thenReturn(Object.class);
+  }
+
+  @Test
+  public void givenDecorators_whenMethodIsIntercepted_thenPreProceedShouldBeCalled()
+      throws Throwable {
+    aspect.trace(pjp);
+
+    verify(decorator).onPreProceed(same(pjp), Matchers.<Span>any());
+  }
+
+  @Test
+  public void givenDecorators_whenMethodIsIntercepted_thenPostProceedShouldBeCalled()
+      throws Throwable {
+    Object result = aspect.trace(pjp);
+
+    verify(decorator).onPostProceed(same(pjp), same(result), Matchers.<Span>any());
+  }
+
+  @Test
+  public void givenNoExceptionOnProceed_whenMethodIsIntercepted_thenOnErrorShouldNotBeCalled()
+      throws Throwable {
+    aspect.trace(pjp);
+
+    verify(decorator, never())
+        .onError(any(ProceedingJoinPoint.class), any(Exception.class), any(Span.class));
+  }
+
+  @Test
+  public void givenExceptionOnProceed_whenMethodIsIntercepted_thenExceptionShouldBeRethrowed()
+      throws Throwable {
+    RuntimeException e = new RuntimeException();
+    when(pjp.proceed()).thenThrow(e);
+    assertThatThrownBy(new ThrowableAssert.ThrowingCallable() {
+      @Override
+      public void call() throws Throwable {
+        aspect.trace(pjp);
+      }
+    }).isSameAs(e);
+  }
+
+  @Test
+  public void givenExceptionOnProceed_whenMethodIsIntercepted_thenOnErrorShouldBeCalled()
+      throws Throwable {
+    RuntimeException e = new RuntimeException();
+    when(pjp.proceed()).thenThrow(e);
+
+    assertThatThrownBy(new ThrowableAssert.ThrowingCallable() {
+      @Override
+      public void call() throws Throwable {
+        aspect.trace(pjp);
+      }
+    }).isSameAs(e);
+
+    verify(decorator).onError(same(pjp), same(e), Matchers.<Span>any());
+  }
+
+  public static class TestTracingAspect extends BaseTracingAspect {
+
+    public TestTracingAspect(Tracer tracer, List<MethodInterceptorSpanDecorator> decorators,
+        Class<? extends Annotation> annotation) {
+      super(tracer, decorators, annotation, Pattern.compile(""));
+    }
+
+    @Override
+    public Object trace(ProceedingJoinPoint pjp) throws Throwable {
+      return super.internalTrace(pjp);
+    }
+
+  }
+
+}

--- a/instrument-starters/opentracing-spring-cloud-core/src/test/java/io/opentracing/contrib/spring/cloud/scheduled/ScheduledTest.java
+++ b/instrument-starters/opentracing-spring-cloud-core/src/test/java/io/opentracing/contrib/spring/cloud/scheduled/ScheduledTest.java
@@ -102,7 +102,7 @@ public class ScheduledTest {
     assertEquals("scheduledFoo", scheduledSpan.operationName());
     assertEquals(3, scheduledSpan.tags().size());
     assertEquals(0, scheduledSpan.logEntries().size());
-    assertEquals(ScheduledAspect.COMPONENT_NAME, scheduledSpan.tags().get(Tags.COMPONENT.getKey()));
+    assertEquals("scheduled", scheduledSpan.tags().get(Tags.COMPONENT.getKey()));
     assertEquals(ScheduledComponent.class.getSimpleName(),
         scheduledSpan.tags().get(ExtensionTags.CLASS_TAG.getKey()));
     assertEquals("scheduledFoo", scheduledSpan.tags().get(ExtensionTags.METHOD_TAG.getKey()));

--- a/instrument-starters/opentracing-spring-cloud-core/src/test/java/io/opentracing/contrib/spring/cloud/traced/TracedAspectTest.java
+++ b/instrument-starters/opentracing-spring-cloud-core/src/test/java/io/opentracing/contrib/spring/cloud/traced/TracedAspectTest.java
@@ -1,0 +1,108 @@
+/**
+ * Copyright 2017-2018 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.contrib.spring.cloud.traced;
+
+import static org.mockito.Mockito.when;
+
+import io.opentracing.Span;
+import io.opentracing.Tracer;
+import io.opentracing.contrib.spring.cloud.aop.MethodInterceptorSpanDecorator;
+import io.opentracing.contrib.spring.cloud.aop.Traced;
+import java.util.List;
+import org.aspectj.lang.ProceedingJoinPoint;
+import org.aspectj.lang.reflect.MethodSignature;
+import org.assertj.core.api.WithAssertions;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.Mock;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class TracedAspectTest implements WithAssertions {
+
+  @Mock
+  private Span span;
+  @Mock
+  private Tracer tracer;
+  @Mock
+  private List<MethodInterceptorSpanDecorator> decorators;
+  @Mock
+  private ProceedingJoinPoint pjp;
+  @Mock
+  private MethodSignature signature;
+  @Mock
+  private TracedTracingProperties tracedTracingProperties;
+
+  private TracedAspect aspect;
+
+  @Before
+  public void init() {
+    when(pjp.getSignature()).thenReturn(signature);
+    when(tracedTracingProperties.getSkipPattern()).thenReturn("");
+    aspect = new TracedAspect(tracer, tracedTracingProperties, decorators);
+  }
+
+  @Test
+  public void givenCustomOperation_whenGettingOperationName_thenOperationNameShouldBeOverriden()
+      throws Throwable {
+    when(signature.getMethod()).thenReturn(TracedClass.class.getMethod("tracedOperation"));
+
+    assertThat(aspect.getOperationName(pjp)).isEqualTo("customOps");
+  }
+
+  @Test
+  public void givenEmptyOperation_whenGettingOperationName_thenOperationNameShouldBeMethodName()
+      throws Throwable {
+    when(signature.getMethod()).thenReturn(TracedClass.class.getMethod("traced"));
+
+    assertThat(aspect.getOperationName(pjp)).isEqualTo("traced");
+  }
+
+
+  @Test
+  public void givenCustomComponent_whenGettingComponent_thenComponentNameShouldBeOverriden()
+      throws Throwable {
+    when(signature.getMethod()).thenReturn(TracedClass.class.getMethod("tracedComponent"));
+
+    assertThat(aspect.getComponent(pjp)).isEqualTo("custom");
+  }
+
+  @Test
+  public void givenDefaultComponent_whenGettingComponent_thenComponentNameShouldBeOverriden()
+      throws Throwable {
+    when(signature.getMethod()).thenReturn(TracedClass.class.getMethod("traced"));
+
+    assertThat(aspect.getComponent(pjp)).isEqualTo("traced");
+  }
+
+  public static class TracedClass {
+
+    @Traced
+    public void traced() {
+
+    }
+
+    @Traced(operationName = "customOps")
+    public void tracedOperation() {
+
+    }
+
+    @Traced(component = "custom")
+    public void tracedComponent() {
+
+    }
+  }
+
+}

--- a/instrument-starters/opentracing-spring-cloud-core/src/test/java/io/opentracing/contrib/spring/cloud/traced/TracedAutoConfigurationTest.java
+++ b/instrument-starters/opentracing-spring-cloud-core/src/test/java/io/opentracing/contrib/spring/cloud/traced/TracedAutoConfigurationTest.java
@@ -1,0 +1,144 @@
+/**
+ * Copyright 2017-2018 The OpenTracing Authors
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.contrib.spring.cloud.traced;
+
+import io.opentracing.Tracer;
+import io.opentracing.contrib.spring.cloud.MockTracingConfiguration;
+import io.opentracing.contrib.spring.cloud.aop.Traced;
+import io.opentracing.mock.MockTracer;
+import io.opentracing.tag.Tags;
+import org.assertj.core.api.WithAssertions;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.autoconfigure.SpringBootApplication;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+@SpringBootTest(webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT)
+@RunWith(SpringJUnit4ClassRunner.class)
+public class TracedAutoConfigurationTest implements WithAssertions {
+
+  @Autowired
+  private TracedClass tracedClass;
+  @Autowired
+  private IgnoredTracedClass ignoredTracedClass;
+  @Autowired
+  private MockTracer tracer;
+
+  @Before()
+  public void setup() {
+    tracer.buildSpan("test").start();
+  }
+
+  @After()
+  public void tearDown() {
+    tracer.reset();
+  }
+
+  @Test
+  public void givenIgnoredClass_whenMethodInvocked_thenNoSpanIsGenerated() {
+    ignoredTracedClass.ignoredTraced();
+    assertThat(tracer.finishedSpans()).isEmpty();
+  }
+
+  @Test
+  public void givenActiveTracer_whenITrace_thenTraceIsGenerated() {
+    tracedClass.traced();
+    assertThat(tracer.finishedSpans()).hasSize(1);
+    assertThat(tracer.finishedSpans().get(0).operationName()).isEqualTo("traced");
+    assertThat(tracer.finishedSpans().get(0).tags().get(Tags.COMPONENT.getKey()))
+        .isEqualTo("traced");
+  }
+
+  @Test
+  public void givenActiveTracer_whenITraceWithCustomComponent_thenTraceIsGenerated() {
+    tracedClass.tracedComponent();
+    assertThat(tracer.finishedSpans()).hasSize(1);
+    assertThat(tracer.finishedSpans().get(0).operationName()).isEqualTo("tracedComponent");
+    assertThat(tracer.finishedSpans().get(0).tags().get(Tags.COMPONENT.getKey()))
+        .isEqualTo("custom");
+  }
+
+  @Test
+  public void givenActiveTracer_whenITraceWithCustomOperation_thenTraceIsGenerated() {
+    tracedClass.tracedOperation();
+    assertThat(tracer.finishedSpans()).hasSize(1);
+    assertThat(tracer.finishedSpans().get(0).operationName()).isEqualTo("customOps");
+    assertThat(tracer.finishedSpans().get(0).tags().get(Tags.COMPONENT.getKey()))
+        .isEqualTo("traced");
+  }
+
+  @Test
+  public void givenActiveTracer_whenITraceWhitChild_thenTraceIsGenerated() {
+    tracedClass.child("someChildSpan");
+    assertThat(tracer.finishedSpans()).hasSize(2);
+    assertThat(tracer.finishedSpans().get(1).operationName()).isEqualTo("child");
+    assertThat(tracer.finishedSpans().get(1).tags().get(Tags.COMPONENT.getKey()))
+        .isEqualTo("traced");
+    assertThat(tracer.finishedSpans().get(0).operationName()).isEqualTo("someChildSpan");
+    assertThat(tracer.finishedSpans().get(0).tags()).isEmpty();
+  }
+
+  @SpringBootApplication
+  @Import(MockTracingConfiguration.class)
+  public static class TestConfig {
+
+    @Bean
+    public TracedClass tracedClass() {
+      return new TracedClass();
+    }
+
+    @Bean
+    public IgnoredTracedClass ignoredTracedClass() {
+      return new IgnoredTracedClass();
+    }
+  }
+
+  public static class TracedClass {
+    @Autowired
+    private Tracer tracer;
+
+    @Traced
+    public void traced() {
+
+    }
+
+    @Traced
+    public void child(String spanName) {
+      tracer.buildSpan(spanName).start().finish();
+    }
+
+    @Traced(operationName = "customOps")
+    public void tracedOperation() {
+
+    }
+
+    @Traced(component = "custom")
+    public void tracedComponent() {
+
+    }
+  }
+  public static class IgnoredTracedClass {
+    @Traced
+    public void ignoredTraced() {
+
+    }
+
+  }
+}

--- a/instrument-starters/opentracing-spring-cloud-core/src/test/resources/application.yml
+++ b/instrument-starters/opentracing-spring-cloud-core/src/test/resources/application.yml
@@ -1,0 +1,2 @@
+opentracing.spring.cloud.traced:
+  skipPattern: .*IgnoredTracedClass

--- a/pom.xml
+++ b/pom.xml
@@ -22,7 +22,8 @@
   <version>0.5.8-SNAPSHOT</version>
   <modules>
     <module>opentracing-spring-cloud-starter</module>
-    <module>/instrument-starters/opentracing-spring-cloud-core</module>
+    <module>instrument-starters/opentracing-spring-cloud-core</module>
+    <module>instrument-starters/opentracing-spring-cloud-aop</module>
     <module>instrument-starters/opentracing-spring-cloud-jdbc-starter</module>
     <module>instrument-starters/opentracing-spring-cloud-jms-starter</module>
     <module>instrument-starters/opentracing-spring-cloud-kafka-starter</module>
@@ -97,7 +98,7 @@
     <version.de.flapdoodle-embed.mongo>2.2.0</version.de.flapdoodle-embed.mongo>
     <version.cz.jirutka.spring-embedmongo-spring>1.3.1</version.cz.jirutka.spring-embedmongo-spring>
     <version.org.slf4j-log4j-over-slf4j>1.7.25</version.org.slf4j-log4j-over-slf4j>
-
+    <version.assertj>3.9.0</version.assertj>
     <version.javax.jms>1.1-rev-1</version.javax.jms>
 
     <!-- plugins -->
@@ -116,6 +117,11 @@
 
   <dependencyManagement>
     <dependencies>
+      <dependency>
+        <groupId>${project.groupId}</groupId>
+        <artifactId>opentracing-spring-cloud-aop</artifactId>
+        <version>${project.version}</version>
+      </dependency>
       <dependency>
         <groupId>${project.groupId}</groupId>
         <artifactId>opentracing-spring-cloud-core</artifactId>
@@ -287,6 +293,11 @@
         <version>${version.org.springframework.boot}</version>
         <type>pom</type>
         <scope>import</scope>
+      </dependency>
+      <dependency>
+        <groupId>org.assertj</groupId>
+        <artifactId>assertj-core</artifactId>
+        <version>${version.assertj}</version>
       </dependency>
     </dependencies>
   </dependencyManagement>


### PR DESCRIPTION
Heavily based on #184 but I removed the MDC bits.

Hopefully this fixes #98 

# Changes:
Add `@Traced` annotation plus `MethodInterceptorSpanDecorator` with a standard implementation and move shared logic from `@Scheduled`/`@Traced` to a base class