### PR TITLE
Upgrade opentracing-spring-web to 4.1.0

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -75,7 +75,7 @@
 
     <version.io.opentracing>0.33.0</version.io.opentracing>
     <version.io.opentracing.contrib-opentracing-spring-tracer-configuration-starter>0.3.1</version.io.opentracing.contrib-opentracing-spring-tracer-configuration-starter>
-    <version.io.opentracing.contrib-opentracing-spring-web>3.0.1</version.io.opentracing.contrib-opentracing-spring-web>
+    <version.io.opentracing.contrib-opentracing-spring-web>4.1.0</version.io.opentracing.contrib-opentracing-spring-web>
     <version.io.opentracing.contrib-opentracing-spring-jms>0.1.7</version.io.opentracing.contrib-opentracing-spring-jms>
     <version.io.opentracing.contrib-opentracing-spring-messaging>1.0.0</version.io.opentracing.contrib-opentracing-spring-messaging>
     <version.io.opentracing.contrib-opentracing-spring-rabbitmq>3.0.0</version.io.opentracing.contrib-opentracing-spring-rabbitmq>


### PR DESCRIPTION
Use latest `opentracing-spring-web` release.

It comes with this bug fix: [#133](https://github.com/opentracing-contrib/java-spring-web/issues/133)
This fix is important for us. Many thanks for the new releasing.