### PR TITLE
Adding support for `@KafkaListener` instrumentation

### DIFF
--- a/instrument-starters/opentracing-spring-cloud-kafka-starter/pom.xml
+++ b/instrument-starters/opentracing-spring-cloud-kafka-starter/pom.xml
@@ -67,6 +67,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.springframework</groupId>
+      <artifactId>spring-aspects</artifactId>
+      <optional>true</optional>
+    </dependency>
+
+    <dependency>
       <groupId>org.springframework.boot</groupId>
       <artifactId>spring-boot-starter-test</artifactId>
       <scope>test</scope>

--- a/instrument-starters/opentracing-spring-cloud-kafka-starter/src/main/java/io/opentracing/contrib/spring/cloud/kafka/KafkaAutoConfiguration.java
+++ b/instrument-starters/opentracing-spring-cloud-kafka-starter/src/main/java/io/opentracing/contrib/spring/cloud/kafka/KafkaAutoConfiguration.java
@@ -15,8 +15,10 @@ package io.opentracing.contrib.spring.cloud.kafka;
 
 import io.opentracing.Tracer;
 import io.opentracing.contrib.kafka.spring.TracingConsumerFactory;
+import io.opentracing.contrib.kafka.spring.TracingKafkaAspect;
 import io.opentracing.contrib.kafka.spring.TracingProducerFactory;
 import io.opentracing.contrib.spring.tracer.configuration.TracerAutoConfiguration;
+import org.springframework.aop.framework.ProxyFactoryBean;
 import org.springframework.beans.BeansException;
 import org.springframework.beans.factory.config.BeanPostProcessor;
 import org.springframework.boot.autoconfigure.AutoConfigureAfter;
@@ -69,5 +71,11 @@ class KafkaAutoConfiguration {
         return bean;
       }
     };
+  }
+
+  @Bean
+  @ConditionalOnClass(ProxyFactoryBean.class)
+  public TracingKafkaAspect tracingKafkaAspect(Tracer tracer) {
+    return new TracingKafkaAspect(tracer);
   }
 }

--- a/pom.xml
+++ b/pom.xml
@@ -88,7 +88,7 @@
     <version.io.opentracing.contrib-opentracing-spring-mongo>0.1.5</version.io.opentracing.contrib-opentracing-spring-mongo>
     <version.io.github.openfeign-feign-okhttp>10.2.0</version.io.github.openfeign-feign-okhttp>
     <version.io.github.openfeign.opentracing>0.4.0</version.io.github.openfeign.opentracing>
-    <version.io.opentracing.contrib-opentracing-kafka-spring>0.1.12</version.io.opentracing.contrib-opentracing-kafka-spring>
+    <version.io.opentracing.contrib-opentracing-kafka-spring>0.1.15</version.io.opentracing.contrib-opentracing-kafka-spring>
     <!-- spring-boot-starter-parent is a module of spring-boot-dependencies
         https://github.com/spring-projects/spring-boot/blob/master/spring-boot-starters/spring-boot-starter-parent/pom.xml -->
     <version.org.springframework.boot>2.2.0.RELEASE</version.org.springframework.boot>


### PR DESCRIPTION
Propagating opentracing-contrib/java-kafka-client#83 in order to add support for `@KafkaListener` instrumentation.
Resolves #295.