### PR TITLE
Fix to prevent override a implicit AsyncTaskExecutor (#313)

### DIFF
--- a/instrument-starters/opentracing-spring-cloud-core/src/main/java/io/opentracing/contrib/spring/cloud/async/DefaultAsyncAutoConfiguration.java
+++ b/instrument-starters/opentracing-spring-cloud-core/src/main/java/io/opentracing/contrib/spring/cloud/async/DefaultAsyncAutoConfiguration.java
@@ -27,6 +27,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.Lazy;
 import org.springframework.core.task.SimpleAsyncTaskExecutor;
+import org.springframework.core.task.TaskExecutor;
 import org.springframework.scheduling.annotation.AsyncConfigurer;
 import org.springframework.scheduling.annotation.AsyncConfigurerSupport;
 import org.springframework.scheduling.annotation.EnableAsync;
@@ -47,7 +48,7 @@ public class DefaultAsyncAutoConfiguration {
   private Tracer tracer;
 
   @Configuration
-  @ConditionalOnMissingBean(AsyncConfigurer.class)
+  @ConditionalOnMissingBean({AsyncConfigurer.class, TaskExecutor.class, Executor.class})
   static class DefaultTracedAsyncConfigurerSupport extends AsyncConfigurerSupport {
 
     @Autowired

--- a/instrument-starters/opentracing-spring-cloud-core/src/test/java/io/opentracing/contrib/spring/cloud/async/AsyncImplicitOneTest.java
+++ b/instrument-starters/opentracing-spring-cloud-core/src/test/java/io/opentracing/contrib/spring/cloud/async/AsyncImplicitOneTest.java
@@ -1,11 +1,11 @@
 /**
  * Copyright 2017-2021 The OpenTracing Authors
- * <p>
+ *
  * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
  * in compliance with the License. You may obtain a copy of the License at
- * <p>
+ *
  * http://www.apache.org/licenses/LICENSE-2.0
- * <p>
+ *
  * Unless required by applicable law or agreed to in writing, software distributed under the License
  * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
  * or implied. See the License for the specific language governing permissions and limitations under
@@ -13,7 +13,15 @@
  */
 package io.opentracing.contrib.spring.cloud.async;
 
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
 import io.opentracing.contrib.spring.cloud.MockTracingConfiguration;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Future;
+
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -24,13 +32,6 @@ import org.springframework.scheduling.annotation.AsyncConfigurer;
 import org.springframework.scheduling.annotation.AsyncResult;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-
-import java.util.concurrent.ExecutionException;
-import java.util.concurrent.Executor;
-import java.util.concurrent.Future;
-
-import static org.junit.Assert.assertEquals;
-import static org.junit.Assert.assertNull;
 
 /**
  * Prevent overriding a implicit AsyncTaskExecutor {@linkplain DefaultAsyncAutoConfiguration}

--- a/instrument-starters/opentracing-spring-cloud-core/src/test/java/io/opentracing/contrib/spring/cloud/async/AsyncImplicitOneTest.java
+++ b/instrument-starters/opentracing-spring-cloud-core/src/test/java/io/opentracing/contrib/spring/cloud/async/AsyncImplicitOneTest.java
@@ -1,0 +1,82 @@
+/**
+ * Copyright 2017-2021 The OpenTracing Authors
+ * <p>
+ * Licensed under the Apache License, Version 2.0 (the "License"); you may not use this file except
+ * in compliance with the License. You may obtain a copy of the License at
+ * <p>
+ * http://www.apache.org/licenses/LICENSE-2.0
+ * <p>
+ * Unless required by applicable law or agreed to in writing, software distributed under the License
+ * is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express
+ * or implied. See the License for the specific language governing permissions and limitations under
+ * the License.
+ */
+package io.opentracing.contrib.spring.cloud.async;
+
+import io.opentracing.contrib.spring.cloud.MockTracingConfiguration;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.annotation.Bean;
+import org.springframework.scheduling.annotation.Async;
+import org.springframework.scheduling.annotation.AsyncConfigurer;
+import org.springframework.scheduling.annotation.AsyncResult;
+import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
+
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Future;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
+
+/**
+ * Prevent overriding a implicit AsyncTaskExecutor {@linkplain DefaultAsyncAutoConfiguration}
+ *
+ * @author Jerry Zhong
+ */
+@SpringBootTest(classes = {AsyncImplicitOneTest.Configuration.class, MockTracingConfiguration.class, DefaultAsyncAutoConfiguration.class})
+@RunWith(SpringJUnit4ClassRunner.class)
+public class AsyncImplicitOneTest {
+
+  public static final String IMPLICIT_THREAD_GROUP = "implicit-thread-group";
+
+  @Autowired(required = false)
+  private AsyncConfigurer asyncConfigurer;
+  @Autowired
+  private AsyncService asyncService;
+
+  @org.springframework.context.annotation.Configuration
+  static class Configuration {
+
+    @Bean
+    public Executor threadPoolTaskExecutor() {
+      ThreadPoolTaskExecutor executor = new ThreadPoolTaskExecutor();
+      executor.setThreadGroupName(IMPLICIT_THREAD_GROUP);
+      executor.initialize();
+      return executor;
+    }
+
+    @Bean
+    public AsyncService asyncService() {
+      return new AsyncService();
+    }
+  }
+
+  static class AsyncService {
+
+    @Async
+    public Future<String> asyncThreadGroupName() {
+      return new AsyncResult<>(Thread.currentThread().getThreadGroup().getName());
+    }
+  }
+
+  @Test
+  public void testNoOverrideImplicitOne() throws ExecutionException, InterruptedException {
+    assertNull(asyncConfigurer);
+    Future<String> asyncFuture = asyncService.asyncThreadGroupName();
+    assertEquals(IMPLICIT_THREAD_GROUP, asyncFuture.get());
+  }
+}


### PR DESCRIPTION
See #313 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved asynchronous task configuration so existing task executors are respected when no custom async configuration is provided.
  - Ensures `@Async` operations run using the application’s configured thread pool and thread settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->