### PR TITLE
Fix websocket autoconfig startup failure caused by Spring Messaging 5.3.2

### DIFF
--- a/instrument-starters/opentracing-spring-cloud-websocket-starter/src/main/java/io/opentracing/contrib/spring/cloud/websocket/TracingChannelInterceptor.java
+++ b/instrument-starters/opentracing-spring-cloud-websocket-starter/src/main/java/io/opentracing/contrib/spring/cloud/websocket/TracingChannelInterceptor.java
@@ -22,7 +22,7 @@ import org.springframework.messaging.Message;
 import org.springframework.messaging.MessageChannel;
 import org.springframework.messaging.MessageHandler;
 import org.springframework.messaging.simp.SimpMessageType;
-import org.springframework.messaging.support.ChannelInterceptorAdapter;
+import org.springframework.messaging.support.ChannelInterceptor;
 import org.springframework.messaging.support.ExecutorChannelInterceptor;
 import org.springframework.messaging.support.MessageBuilder;
 import org.springframework.web.socket.messaging.SubProtocolWebSocketHandler;
@@ -32,8 +32,7 @@ import org.springframework.web.socket.messaging.WebSocketAnnotationMethodMessage
  * This class implements a {@link ExecutorChannelInterceptor} to instrument the websocket
  * communications using an OpenTracing Tracer.
  */
-public class TracingChannelInterceptor extends ChannelInterceptorAdapter implements
-    ExecutorChannelInterceptor {
+public class TracingChannelInterceptor implements ChannelInterceptor, ExecutorChannelInterceptor {
 
   /**
    * The span component tag value.
@@ -66,8 +65,8 @@ public class TracingChannelInterceptor extends ChannelInterceptorAdapter impleme
    */
   protected static final String OPENTRACING_SCOPE = "opentracing.scope";
 
-  private Tracer tracer;
-  private String spanKind;
+  private final Tracer tracer;
+  private final String spanKind;
 
   public TracingChannelInterceptor(Tracer tracer, String spanKind) {
     this.tracer = tracer;

--- a/instrument-starters/opentracing-spring-cloud-websocket-starter/src/main/java/io/opentracing/contrib/spring/cloud/websocket/WebsocketAutoConfiguration.java
+++ b/instrument-starters/opentracing-spring-cloud-websocket-starter/src/main/java/io/opentracing/contrib/spring/cloud/websocket/WebsocketAutoConfiguration.java
@@ -23,6 +23,7 @@ import org.springframework.boot.autoconfigure.condition.ConditionalOnClass;
 import org.springframework.boot.autoconfigure.condition.ConditionalOnProperty;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
+import org.springframework.messaging.support.AbstractMessageChannel;
 import org.springframework.messaging.support.ChannelInterceptor;
 import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurationSupport;
 
@@ -37,22 +38,22 @@ public class WebsocketAutoConfiguration {
   private Tracer tracer;
 
   @Bean
-  @ConditionalOnBean(WebSocketMessageBrokerConfigurationSupport.class)
+  @ConditionalOnBean(value = AbstractMessageChannel.class, name = "clientInboundChannel")
   public TracingChannelInterceptor tracingInboundChannelInterceptor(
-      WebSocketMessageBrokerConfigurationSupport config) {
+      AbstractMessageChannel clientInboundChannel) {
     TracingChannelInterceptor interceptor = new TracingChannelInterceptor(tracer,
         Tags.SPAN_KIND_SERVER);
-    config.clientInboundChannel().addInterceptor(interceptor);
+    clientInboundChannel.addInterceptor(interceptor);
     return interceptor;
   }
 
   @Bean
-  @ConditionalOnBean(WebSocketMessageBrokerConfigurationSupport.class)
+  @ConditionalOnBean(value = AbstractMessageChannel.class, name = "clientOutboundChannel")
   public TracingChannelInterceptor tracingOutboundChannelInterceptor(
-      WebSocketMessageBrokerConfigurationSupport config) {
+      AbstractMessageChannel clientOutboundChannel) {
     TracingChannelInterceptor interceptor = new TracingChannelInterceptor(tracer,
         Tags.SPAN_KIND_CLIENT);
-    config.clientOutboundChannel().addInterceptor(interceptor);
+    clientOutboundChannel.addInterceptor(interceptor);
     return interceptor;
   }
 }

--- a/instrument-starters/opentracing-spring-cloud-websocket-starter/src/test/java/io/opentracing/contrib/spring/cloud/websocket/WebSocketConfig.java
+++ b/instrument-starters/opentracing-spring-cloud-websocket-starter/src/test/java/io/opentracing/contrib/spring/cloud/websocket/WebSocketConfig.java
@@ -16,14 +16,14 @@ package io.opentracing.contrib.spring.cloud.websocket;
 import org.springframework.boot.autoconfigure.EnableAutoConfiguration;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
-import org.springframework.web.socket.config.annotation.AbstractWebSocketMessageBrokerConfigurer;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
 
 @Configuration
 @EnableWebSocketMessageBroker
 @EnableAutoConfiguration
-public class WebSocketConfig extends AbstractWebSocketMessageBrokerConfigurer {
+public class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
   @Override
   public void configureMessageBroker(MessageBrokerRegistry config) {

--- a/opentracing-spring-cloud-starter/src/test/java/io/opentracing/contrib/spring/cloud/websocket/WebsocketTest.java
+++ b/opentracing-spring-cloud-starter/src/test/java/io/opentracing/contrib/spring/cloud/websocket/WebsocketTest.java
@@ -27,9 +27,9 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.messaging.simp.config.MessageBrokerRegistry;
 import org.springframework.test.context.junit4.SpringJUnit4ClassRunner;
-import org.springframework.web.socket.config.annotation.AbstractWebSocketMessageBrokerConfigurer;
 import org.springframework.web.socket.config.annotation.EnableWebSocketMessageBroker;
 import org.springframework.web.socket.config.annotation.StompEndpointRegistry;
+import org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer;
 
 @SpringBootTest(
     webEnvironment = SpringBootTest.WebEnvironment.RANDOM_PORT,
@@ -40,7 +40,7 @@ public class WebsocketTest {
   @Configuration
   @EnableWebSocketMessageBroker
   @EnableAutoConfiguration
-  public static class WebSocketConfig extends AbstractWebSocketMessageBrokerConfigurer {
+  public static class WebSocketConfig implements WebSocketMessageBrokerConfigurer {
 
     @Bean
     public Tracer tracer() {


### PR DESCRIPTION
* Replace usage of WebSocketMessageBrokerConfigurationSupport to access the client inbound/outbound channels with the beans directly since there are no factories or decorators to customize these channels. 
* ChannelInterceptorAdapter deprecation warning `Deprecated as of 5.0.7 ChannelInterceptor has default methods (made possible by a Java 8 baseline) and can be implemented directly without the need for this no-op adapter`. Replaced with the suggested action.
* AbstractWebSocketMessageBrokerConfigurer deprecation warning `Deprecated as of 5.0 in favor of simply using WebSocketMessageBrokerConfigurer which has default methods, made possible by a Java 8 baseline.`. Replaced with the suggested action.

relates to issue #308