### PR TITLE
Remove support for LoadBalancerFeignClient

### DIFF
--- a/instrument-starters/opentracing-spring-cloud-feign-starter/src/main/java/io/opentracing/contrib/spring/cloud/feign/FeignContextBeanPostProcessor.java
+++ b/instrument-starters/opentracing-spring-cloud-feign-starter/src/main/java/io/opentracing/contrib/spring/cloud/feign/FeignContextBeanPostProcessor.java
@@ -27,20 +27,17 @@ import org.springframework.cloud.openfeign.FeignContext;
 public class FeignContextBeanPostProcessor implements BeanPostProcessor {
 
   private Tracer tracer;
-  private BeanFactory beanFactory;
   private List<FeignSpanDecorator> spanDecorators;
 
-  FeignContextBeanPostProcessor(Tracer tracer, BeanFactory beanFactory,
-      List<FeignSpanDecorator> spanDecorators) {
+  FeignContextBeanPostProcessor(Tracer tracer, List<FeignSpanDecorator> spanDecorators) {
     this.tracer = tracer;
-    this.beanFactory = beanFactory;
     this.spanDecorators = spanDecorators;
   }
 
   @Override
   public Object postProcessBeforeInitialization(Object bean, String name) throws BeansException {
     if (bean instanceof FeignContext && !(bean instanceof TraceFeignContext)) {
-      return new TraceFeignContext(tracer, (FeignContext) bean, beanFactory, spanDecorators);
+      return new TraceFeignContext(tracer, (FeignContext) bean, spanDecorators);
     }
     return bean;
   }

--- a/instrument-starters/opentracing-spring-cloud-feign-starter/src/main/java/io/opentracing/contrib/spring/cloud/feign/FeignTracingAutoConfiguration.java
+++ b/instrument-starters/opentracing-spring-cloud-feign-starter/src/main/java/io/opentracing/contrib/spring/cloud/feign/FeignTracingAutoConfiguration.java
@@ -58,8 +58,8 @@ public class FeignTracingAutoConfiguration {
 
   @Bean
   @ConditionalOnClass(name = "org.springframework.cloud.openfeign.FeignContext")
-  FeignContextBeanPostProcessor feignContextBeanPostProcessor(BeanFactory beanFactory) {
-    return new FeignContextBeanPostProcessor(tracer, beanFactory, spanDecorators);
+  FeignContextBeanPostProcessor feignContextBeanPostProcessor() {
+    return new FeignContextBeanPostProcessor(tracer, spanDecorators);
   }
 
   @Configuration

--- a/instrument-starters/opentracing-spring-cloud-feign-starter/src/main/java/io/opentracing/contrib/spring/cloud/feign/TraceFeignContext.java
+++ b/instrument-starters/opentracing-spring-cloud-feign-starter/src/main/java/io/opentracing/contrib/spring/cloud/feign/TraceFeignContext.java
@@ -19,7 +19,6 @@ import io.opentracing.Tracer;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.springframework.beans.factory.BeanFactory;
 import org.springframework.cloud.openfeign.FeignContext;
 
 /**
@@ -30,10 +29,9 @@ class TraceFeignContext extends FeignContext {
   private final FeignContext delegate;
   private final TracedFeignBeanFactory tracedFeignBeanFactory;
 
-  TraceFeignContext(Tracer tracer, FeignContext delegate, BeanFactory beanFactory,
-                    List<FeignSpanDecorator> spanDecorators) {
+  TraceFeignContext(Tracer tracer, FeignContext delegate, List<FeignSpanDecorator> spanDecorators) {
     this.delegate = delegate;
-    this.tracedFeignBeanFactory = new TracedFeignBeanFactory(tracer, beanFactory, spanDecorators);
+    this.tracedFeignBeanFactory = new TracedFeignBeanFactory(tracer, spanDecorators);
   }
 
   @SuppressWarnings("unchecked")


### PR DESCRIPTION
LoadBalancerFeignClient was removed in spring-cloud-openfeign(see [here](https://github.com/spring-cloud/spring-cloud-openfeign/commit/8a08e1ec4b4f0d40193a4ea9c03afdeffe3110a6)), so this code might raise errors (`ClassNotFoundException` or `NoClassDefFoundError`) when used with newer spring versions.

Since it seems the underlying functionality was removed, I guess this code can just be removed as well.