### PR TITLE
Shallow cloning on travis

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,7 +5,7 @@ group: deprecated-2017Q4
 git:
   # otherwise license plugin fails due to grafted commits
   # see https://github.com/travis-ci/travis-ci/issues/7254#issuecomment-387689631
-  depth: false
+  depth: 3
 
 language: java
 jdk:


### PR DESCRIPTION
According to [https://docs.travis-ci.com/user/customizing-the-build#git-clone-depth](url), Travis CI provide a way to shallow clone a repository. This has the obvious benefit of speed, since you only need to download a small number of commits.