### PR TITLE
Wrap Redis connection based on type of RedisConnection in RedisAspect

### DIFF
--- a/instrument-starters/opentracing-spring-cloud-redis-starter/src/main/java/io/opentracing/contrib/spring/cloud/redis/RedisAspect.java
+++ b/instrument-starters/opentracing-spring-cloud-redis-starter/src/main/java/io/opentracing/contrib/spring/cloud/redis/RedisAspect.java
@@ -56,10 +56,10 @@ public class RedisAspect {
 
   /**
    * Intercepts calls to {@link RedisConnectionFactory#getConnection()} (and related), wrapping the
-   * outcome in a {@link TracingRedisConnection}
+   * outcome in a {@link TracingRedisConnection} or a {@link TracingRedisClusterConnection}
    *
    * @param pjp the intercepted join point
-   * @return a new {@link TracingRedisConnection} wrapping the result of the joint point
+   * @return a new {@link TracingRedisConnection} or {@link TracingRedisClusterConnection} wrapping the result of the joint point
    */
   @Around("getConnection() && connectionFactory()")
   public Object aroundGetConnection(final ProceedingJoinPoint pjp) throws Throwable {
@@ -70,6 +70,9 @@ public class RedisAspect {
         .withSpanNameProvider(RedisSpanNameProvider.PREFIX_OPERATION_NAME(prefixOperationName))
         .build();
 
+    if(connection instanceof RedisClusterConnection) {
+      return new TracingRedisClusterConnection((RedisClusterConnection) connection, tracingConfiguration);
+    }
     return new TracingRedisConnection(connection, tracingConfiguration);
   }
 


### PR DESCRIPTION
Wrap the redis connection based on the type either as a
TracingRedisClusterConnection or TracingRedisConnection.

Relates to #336