### PR TITLE
Upgrade opentracing-spring-redis to 0.1.16

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -82,7 +82,7 @@
     <version.io.opentracing.contrib-opentracing-spring-rabbitmq>3.0.0</version.io.opentracing.contrib-opentracing-spring-rabbitmq>
     <version.io.opentracing.contrib-java-jdbc>0.2.11</version.io.opentracing.contrib-java-jdbc>
     <version.io.opentracing.contrib-common>0.1.4</version.io.opentracing.contrib-common>
-    <version.io.opentracing.contrib-opentracing-spring-redis>0.1.14</version.io.opentracing.contrib-opentracing-spring-redis>
+    <version.io.opentracing.contrib-opentracing-spring-redis>0.1.16</version.io.opentracing.contrib-opentracing-spring-redis>
     <version.io.opentracing.contrib-java-concurrent>0.4.0</version.io.opentracing.contrib-java-concurrent>
     <version.io.opentracing.contrib-opentracing-reactor>0.2.0</version.io.opentracing.contrib-opentracing-reactor>
     <version.io.opentracing.contrib-opentracing-rxjava-1>0.1.3</version.io.opentracing.contrib-opentracing-rxjava-1>


### PR DESCRIPTION
Use latest opentracing-spring-redis release.

It comes with this bug fix: https://github.com/opentracing-contrib/java-redis-client/pull/51