### PR TITLE
Fix JCenter/Bintray as an artifact repository

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -332,7 +332,7 @@
   <distributionManagement>
     <repository>
       <id>bintray</id>
-      <url>https://api.bintray.com/maven/opentracing/maven/opentracing-spring-cloud/;publish=1</url>
+      <url>https://oss.jfrog.org/artifactory/oss-release-local</url>
     </repository>
     <snapshotRepository>
       <id>jfrog-snapshots</id>


### PR DESCRIPTION
Potential fix for [https://github.com/opentracing-contrib/java-spring-cloud/security/code-scanning/1](https://github.com/opentracing-contrib/java-spring-cloud/security/code-scanning/1)

To fix this safely without changing project behavior beyond replacing the deprecated repository, update the `distributionManagement` release repository in `pom.xml` to a supported canonical host for OpenTracing artifacts (JFrog OSS Artifactory, matching the existing snapshot repository family).

Best single fix in this snippet:
- In `pom.xml`, within `<distributionManagement>` (around lines 332–340), replace the `<repository>` entry that currently uses Bintray:
  - keep the `<id>` as `bintray` to minimize credential/profile disruption,
  - replace only the `<url>` with the JFrog OSS release-local endpoint:
    `https://oss.jfrog.org/artifactory/oss-release-local`.

No imports/dependencies/methods are needed (XML config only).


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the release repository configuration to use the current JFrog Artifactory OSS endpoint instead of the deprecated Bintray service.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->