### PR TITLE
Add publish steps

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,7 +5,7 @@ on:
     branches:
       - master
     tags:
-      - "*"
+      - "v*"
   pull_request:
     branches:
       - master
@@ -112,3 +112,92 @@ jobs:
 
       - name: Run classpath tests
         run: make PROFILES=${{ matrix.profile }} classpath
+
+  publish:
+    name: Publish to Maven Central
+    needs: [test, classpath]
+    if: github.event_name == 'push' && startsWith(github.ref, 'refs/tags/v')
+    runs-on: ubuntu-24.04
+    permissions:
+      contents: read
+      packages: write
+    env:
+      CENTRAL_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Java
+        uses: actions/setup-java@v6
+        with:
+          distribution: temurin
+          java-version: '11'
+          cache: maven
+          server-id: central
+          server-username: CENTRAL_USERNAME
+          server-password: CENTRAL_TOKEN
+          gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
+          gpg-passphrase: GPG_PASSPHRASE
+
+      - name: Verify tag matches pom version
+        run: |
+          TAG_VERSION=${GITHUB_REF#refs/tags/v}
+          POM_VERSION=$(./mvnw help:evaluate -N -Dexpression=project.version -q -DforceStdout | grep -v '\[')
+          echo "Tag version: $TAG_VERSION"
+          echo "POM version: $POM_VERSION"
+          if [[ "$POM_VERSION" != "$TAG_VERSION" ]]; then
+            echo "::error::Tag $TAG_VERSION does not match pom $POM_VERSION"
+            echo "::warning::Tag $TAG_VERSION does not match pom $POM_VERSION (expected if release:prepare not used with v prefix))"
+            exit 1
+          fi
+
+      - name: Publish to GitHub Packages
+        run: ./mvnw --batch-mode -Pgithub -DskipTests deploy
+
+      - name: Publish release to Maven Central
+        if: ${{ env.CENTRAL_USERNAME != '' }}
+        env:
+          CENTRAL_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
+          CENTRAL_TOKEN: ${{ secrets.CENTRAL_TOKEN }}
+          GPG_PASSPHRASE: ${{ secrets.GPG_PASSPHRASE }}
+        run: ./mvnw --batch-mode -Prelease -DskipTests deploy
+
+  snapshot:
+    name: Publish snapshot
+    if: github.event_name == 'push' && github.ref == 'refs/heads/master'
+    runs-on: ubuntu-24.04
+    needs: [test, classpath]
+    permissions:
+      contents: read
+      packages: write
+    env:
+      CENTRAL_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+          persist-credentials: false
+
+      - name: Set up Java
+        uses: actions/setup-java@v6
+        with:
+          distribution: temurin
+          java-version: '11'
+          cache: maven
+          server-id: github
+          server-username: GITHUB_ACTOR
+          server-password: GITHUB_TOKEN
+
+      - name: Publish snapshot to GitHub Packages
+        run: ./mvnw --batch-mode -Pgithub -DskipTests deploy
+
+      - name: Publish snapshot to Maven Central
+        if: ${{ env.CENTRAL_USERNAME != '' }}
+        env:
+          CENTRAL_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
+          CENTRAL_TOKEN: ${{ secrets.CENTRAL_TOKEN }}
+        run: ./mvnw --batch-mode -DskipTests deploy

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,22 +137,11 @@ jobs:
           distribution: temurin
           java-version: '11'
           cache: maven
-          server-id: central
-          server-username: CENTRAL_USERNAME
-          server-password: CENTRAL_TOKEN
+          mvn-server-credentials: |
+            central:CENTRAL_USERNAME:CENTRAL_TOKEN
+            github:GITHUB_ACTOR:GITHUB_TOKEN
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
-          gpg-passphrase: GPG_PASSPHRASE
-
-      - name: Set up Java (GitHub)
-        uses: actions/setup-java@v6
-        with:
-          distribution: temurin
-          java-version: '11'
-          cache: maven
-          server-id: github
-          server-username: GITHUB_ACTOR
-          server-password: GITHUB_TOKEN
-          overwrite-settings: false
+          gpg-passphrase-env-var: GPG_PASSPHRASE
 
       - name: Verify tag matches pom version
         run: |
@@ -203,20 +192,9 @@ jobs:
           distribution: temurin
           java-version: '11'
           cache: maven
-          server-id: github
-          server-username: GITHUB_ACTOR
-          server-password: GITHUB_TOKEN
-
-      - name: Set up Java (Central)
-        uses: actions/setup-java@v6
-        with:
-          distribution: temurin
-          java-version: '11'
-          cache: maven
-          server-id: central
-          server-username: CENTRAL_USERNAME
-          server-password: CENTRAL_TOKEN
-          overwrite-settings: false
+          mvn-server-credentials: |
+            central:CENTRAL_USERNAME:CENTRAL_TOKEN
+            github:GITHUB_ACTOR:GITHUB_TOKEN
 
       - name: Publish snapshot to GitHub Packages
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,6 +123,7 @@ jobs:
       packages: write
     env:
       CENTRAL_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
@@ -142,6 +143,17 @@ jobs:
           gpg-private-key: ${{ secrets.GPG_PRIVATE_KEY }}
           gpg-passphrase: GPG_PASSPHRASE
 
+      - name: Set up Java (GitHub)
+        uses: actions/setup-java@v6
+        with:
+          distribution: temurin
+          java-version: '11'
+          cache: maven
+          server-id: github
+          server-username: GITHUB_ACTOR
+          server-password: GITHUB_TOKEN
+          overwrite-settings: false
+
       - name: Verify tag matches pom version
         run: |
           TAG_VERSION=${GITHUB_REF#refs/tags/v}
@@ -155,6 +167,8 @@ jobs:
           fi
 
       - name: Publish to GitHub Packages
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./mvnw --batch-mode -Pgithub -DskipTests deploy
 
       - name: Publish release to Maven Central
@@ -175,6 +189,7 @@ jobs:
       packages: write
     env:
       CENTRAL_USERNAME: ${{ secrets.CENTRAL_USERNAME }}
+      GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Checkout repository
         uses: actions/checkout@v7
@@ -192,7 +207,20 @@ jobs:
           server-username: GITHUB_ACTOR
           server-password: GITHUB_TOKEN
 
+      - name: Set up Java (Central)
+        uses: actions/setup-java@v6
+        with:
+          distribution: temurin
+          java-version: '11'
+          cache: maven
+          server-id: central
+          server-username: CENTRAL_USERNAME
+          server-password: CENTRAL_TOKEN
+          overwrite-settings: false
+
       - name: Publish snapshot to GitHub Packages
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         run: ./mvnw --batch-mode -Pgithub -DskipTests deploy
 
       - name: Publish snapshot to Maven Central

--- a/.settings.xml
+++ b/.settings.xml
@@ -22,19 +22,14 @@
                           http://maven.apache.org/xsd/settings-1.0.0.xsd">
   <servers>
     <server>
-      <id>sonatype</id>
-      <username>${env.SONATYPE_USER}</username>
-      <password>${env.SONATYPE_PASSWORD}</password>
+      <id>central</id>
+      <username>${env.CENTRAL_USERNAME}</username>
+      <password>${env.CENTRAL_TOKEN}</password>
     </server>
     <server>
-      <id>bintray</id>
-      <username>${env.BINTRAY_USER}</username>
-      <password>${env.BINTRAY_KEY}</password>
-    </server>
-    <server>
-      <id>jfrog-snapshots</id>
-      <username>${env.BINTRAY_USER}</username>
-      <password>${env.BINTRAY_KEY}</password>
+      <id>github</id>
+      <username>${env.GITHUB_ACTOR}</username>
+      <password>${env.GITHUB_TOKEN}</password>
     </server>
     <server>
       <id>github.com</id>

--- a/pom.xml
+++ b/pom.xml
@@ -94,7 +94,7 @@
     <!-- spring-boot-starter-parent is a module of spring-boot-dependencies
         https://github.com/spring-projects/spring-boot/blob/master/spring-boot-starters/spring-boot-starter-parent/pom.xml -->
     <version.org.springframework.boot>2.2.0.RELEASE</version.org.springframework.boot>
-    <version.org.springframework.cloud-spring-cloud-dependencies>Hoxton.SR1</version.org.springframework.cloud-spring-cloud-dependencies>
+    <version.org.springframework.cloud-spring-cloud-dependencies>Hoxton.SR12</version.org.springframework.cloud-spring-cloud-dependencies>
     <version.org.awaitility-awaitility>4.3.0</version.org.awaitility-awaitility>
     <version.de.flapdoodle-embed.mongo>2.2.0</version.de.flapdoodle-embed.mongo>
     <version.cz.jirutka.spring-embedmongo-spring>1.3.1</version.cz.jirutka.spring-embedmongo-spring>
@@ -114,6 +114,7 @@
     <version.checkstyle>10.26.1</version.checkstyle>
     <version.io.takari-maven>0.7.7</version.io.takari-maven>
     <version.io.zikin.centralsync-maven-plugin>0.1.1</version.io.zikin.centralsync-maven-plugin>
+    <version.maven-gpg-plugin>3.2.7</version.maven-gpg-plugin>
   </properties>
 
   <dependencyManagement>
@@ -331,12 +332,12 @@
 
   <distributionManagement>
     <repository>
-      <id>bintray</id>
-      <url>https://oss.jfrog.org/artifactory/oss-release-local</url>
+      <id>central</id>
+      <url>https://central.sonatype.com/repository/maven-releases/</url>
     </repository>
     <snapshotRepository>
-      <id>jfrog-snapshots</id>
-      <url>https://oss.jfrog.org/artifactory/oss-snapshot-local</url>
+      <id>central</id>
+      <url>https://central.sonatype.com/repository/maven-snapshots/</url>
     </snapshotRepository>
   </distributionManagement>
 
@@ -404,7 +405,7 @@
           <useReleaseProfile>false</useReleaseProfile>
           <releaseProfiles>release</releaseProfiles>
           <autoVersionSubmodules>true</autoVersionSubmodules>
-          <tagNameFormat>@{project.version}</tagNameFormat>
+          <tagNameFormat>v@{project.version}</tagNameFormat>
         </configuration>
       </plugin>
       <plugin>
@@ -499,8 +500,42 @@
               </execution>
             </executions>
           </plugin>
+          <!-- GPG signing for Maven Central -->
+          <plugin>
+            <groupId>org.apache.maven.plugins</groupId>
+            <artifactId>maven-gpg-plugin</artifactId>
+            <version>3.2.7</version>
+            <executions>
+              <execution>
+                <id>sign-artifacts</id>
+                <phase>verify</phase>
+                <goals>
+                  <goal>sign</goal>
+                </goals>
+                <configuration>
+                  <gpgArguments>
+                    <arg>--pinentry-mode</arg>
+                    <arg>loopback</arg>
+                  </gpgArguments>
+                </configuration>
+              </execution>
+            </executions>
+          </plugin>
         </plugins>
       </build>
+    </profile>
+    <profile>
+      <id>github</id>
+      <distributionManagement>
+        <repository>
+          <id>github</id>
+          <url>https://maven.pkg.github.com/opentracing-contrib/java-spring-cloud</url>
+        </repository>
+        <snapshotRepository>
+          <id>github</id>
+          <url>https://maven.pkg.github.com/opentracing-contrib/java-spring-cloud</url>
+        </snapshotRepository>
+      </distributionManagement>
     </profile>
   </profiles>
 </project>

--- a/pom.xml
+++ b/pom.xml
@@ -114,6 +114,7 @@
     <version.checkstyle>10.26.1</version.checkstyle>
     <version.io.takari-maven>0.7.7</version.io.takari-maven>
     <version.io.zikin.centralsync-maven-plugin>0.1.1</version.io.zikin.centralsync-maven-plugin>
+    <version.org.sonatype.central-publishing-maven-plugin>0.7.0</version.org.sonatype.central-publishing-maven-plugin>
     <version.maven-gpg-plugin>3.2.7</version.maven-gpg-plugin>
   </properties>
 
@@ -331,10 +332,6 @@
   </dependencies>
 
   <distributionManagement>
-    <repository>
-      <id>central</id>
-      <url>https://central.sonatype.com/repository/maven-releases/</url>
-    </repository>
     <snapshotRepository>
       <id>central</id>
       <url>https://central.sonatype.com/repository/maven-snapshots/</url>
@@ -504,7 +501,7 @@
           <plugin>
             <groupId>org.apache.maven.plugins</groupId>
             <artifactId>maven-gpg-plugin</artifactId>
-            <version>3.2.7</version>
+            <version>${version.maven-gpg-plugin}</version>
             <executions>
               <execution>
                 <id>sign-artifacts</id>
@@ -520,6 +517,18 @@
                 </configuration>
               </execution>
             </executions>
+          </plugin>
+          <!-- Central Publisher Portal - autoPublish via staging API -->
+          <plugin>
+            <groupId>org.sonatype.central</groupId>
+            <artifactId>central-publishing-maven-plugin</artifactId>
+            <version>${version.org.sonatype.central-publishing-maven-plugin}</version>
+            <extensions>true</extensions>
+            <configuration>
+              <publishingServerId>central</publishingServerId>
+              <autoPublish>true</autoPublish>
+              <waitUntil>published</waitUntil>
+            </configuration>
           </plugin>
         </plugins>
       </build>


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Release Management**
  * Releases now run only for version tags and verify that each tag matches the project version.
  * Release and snapshot artifacts can be published to GitHub Packages and Maven Central.
  * Release artifacts are signed and automatically published after validation.
  * Snapshot deployments continue to use Maven Central.

* **Maintenance**
  * Updated the Spring Cloud dependency baseline to Hoxton.SR12.
  * Updated publishing configuration for GitHub Packages and Maven Central.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->